### PR TITLE
Reduce likelyhood to reuse BDI ids to reduce risk of race condition

### DIFF
--- a/asr1k_neutron_l3/common/asr1k_exceptions.py
+++ b/asr1k_neutron_l3/common/asr1k_exceptions.py
@@ -25,6 +25,10 @@ class RdPoolExhausted(nexception.NotFound):
     message = "No free RD could be allocated to the router. Please raise an issue with support."
 
 
+class SecondDot1QPoolExhausted(nexception.NotFound):
+    message = "No free second dot1q id could be allocated for agent host %(agent_host)s."
+
+
 class DeviceUnreachable(BaseException):
     message = "Device %(host)s is not reachable"
 

--- a/asr1k_neutron_l3/plugins/db/asr1k_db.py
+++ b/asr1k_neutron_l3/plugins/db/asr1k_db.py
@@ -14,6 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import random
+
 import sqlalchemy as sa
 from oslo_log import helpers as log_helpers
 from oslo_log import log
@@ -529,6 +531,7 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
 
 class ExtraAttsDb(object):
+
     @classmethod
     def ensure(cls, router_id, port, segment):
         context = n_context.get_admin_context()
@@ -570,22 +573,19 @@ class ExtraAttsDb(object):
 
     def set_next_entries(self):
         extra_atts = self.session.query(asr1k_models.ASR1KExtraAttsModel).filter_by(agent_host=self.agent_host)
-        second_dot1qs = []
+        second_dot1qs_used = set([item.second_dot1q for item in extra_atts])
+        second_dot1qs_available = list(set(range(MIN_SECOND_DOT1Q, MAX_SECOND_DOT1Q)) - second_dot1qs_used)
+        if len(second_dot1qs_available) == 0:
+            raise asr1k_exceptions.SecondDot1QPoolExhausted(agent_host=self.agent_host)
+        self.second_dot1q = random.choice(second_dot1qs_available)
 
-        for extra_att in extra_atts:
-            second_dot1qs.append(extra_att.second_dot1q)
-
-        for x in range(MIN_SECOND_DOT1Q, MAX_SECOND_DOT1Q):
-            if x not in second_dot1qs:
-                self.second_dot1q = x
-                break
 
     def _ensure(self):
         if not self._record_exists:
             LOG.debug("L2 extra atts not existing, attempting create")
-            self.set_next_entries()
 
             with self.session.begin(subtransactions=True):
+                self.set_next_entries()
                 extra_atts = asr1k_models.ASR1KExtraAttsModel(
                     router_id=self.router_id,
                     agent_host=self.agent_host,


### PR DESCRIPTION
In order to avoid a race condition in the ASR firmware, we reduce the
likelyhood of BDI ids beeing reused soon after they have been deleted.
We do that by randomly picking a seconddot1q id (which is later set as
BDI id) from all free seconddot1q ids. Hence, BDI id reuse probability
is 1/len(free_seconddot1qs).

The former implementations went by numeric order and just selected the
next available id thus having a much larger risk of reuse.

In this PR we also move the fetch of the available seconddot1qs into the
database transaction, removing the possibilty of another thread then
executing a dirty read.