### PR TITLE
Reduce likelyhood to reuse BDI ids / RDs to reduce risk of race condition

### DIFF
--- a/asr1k_neutron_l3/common/asr1k_exceptions.py
+++ b/asr1k_neutron_l3/common/asr1k_exceptions.py
@@ -25,6 +25,10 @@ class RdPoolExhausted(nexception.NotFound):
     message = "No free RD could be allocated to the router. Please raise an issue with support."
 
 
+class SecondDot1QPoolExhausted(nexception.NotFound):
+    message = "No free second dot1q id could be allocated for agent host %(agent_host)s."
+
+
 class DeviceUnreachable(BaseException):
     message = "Device %(host)s is not reachable"
 


### PR DESCRIPTION
In order to avoid a race condition in the ASR firmware, we reduce the
likelyhood of BDI ids beeing reused soon after they have been deleted.
We do that by randomly picking a seconddot1q id (which is later set as
BDI id) from all free seconddot1q ids. Hence, BDI id reuse probability
is 1/len(free_seconddot1qs). We employ the same principal for VRF Route
Distinguishers as a VRF RD might still be bound to a to-be-deleted VRF
when it was assigned to a to-be-created VRF. The configuration of the
new VRF then triggers the deletion of the old VRF immediatly followed by
the new VRF's creation. This is expected to cause a race condition in
the ASR firmware. In order to avoid this behaviour we randomize RD
values to avoid a create-after-delete situation.

The former implementations went by numeric order and just selected the
next available id thus having a much larger risk of reuse.

In this PR we also move the fetch of the available seconddot1qs into the
database transaction, removing the possibilty of another thread then
executing a dirty read.**