### PR TITLE
Reset version discovery when device marked dead

### DIFF
--- a/asr1k_neutron_l3/models/asr1k_pair.py
+++ b/asr1k_neutron_l3/models/asr1k_pair.py
@@ -97,6 +97,12 @@ class ASR1KContext(ASR1KContextBase):
     def use_bdvif(self):
         return self.version_min_17_3 and not self.force_bdi
 
+    def mark_alive(self, alive):
+        if not alive:
+            LOG.debug("Device %s marked as dead, resetting version info", self.host)
+            self._got_version_info = False
+        self.alive = alive
+
 
 class ASR1KPair(object):
     __instance = None

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -78,7 +78,7 @@ def check_devices(device_info):
 
         alive = device_reachable and admin_up
 
-        context.alive = alive
+        context.mark_alive(alive)
         LOG.debug("Device {} reachable {} and agent enabled {}, marked as {}"
                   "".format(context.host, device_reachable, admin_up, "alive" if alive else "dead"))
 
@@ -244,7 +244,7 @@ class YangConnection(object):
                 LOG.warning(
                     "Failed to connect due to '{}', connection will be attempted again in subsequent iterations".format(
                         e))
-                self.context.alive = False
+                self.context.mark_alive(False)
             else:
                 LOG.exception(e)
 

--- a/asr1k_neutron_l3/models/netconf_yang/ny_base.py
+++ b/asr1k_neutron_l3/models/netconf_yang/ny_base.py
@@ -185,7 +185,7 @@ class retry_on_failure(object):
                             LOG.error("Device {} not reachable anymore, setting alive to false".format(host),
                                       exc_info=exc_info_full())
                         LOG.debug("** [{}] request {}: Device is not reachable anymore: {}".format(host, uuid, e))
-                        context.alive = False
+                        context.mark_alive(False)
                     break
                 except exc.EntityNotEmptyException as e:
                     if total_retry < self.max_retry_interval:


### PR DESCRIPTION
When a device is marked as dead it is possible that it is currently
rebooting, maybe with a new version. To be able to discover a new
version we reset the version info on this occasion.