### PR TITLE
Reintroduce BD-VIF config switch

### DIFF
--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -28,6 +28,7 @@ DEVICE_OPTS = [
     cfg.IntOpt('nc_timeout', default=(5), help=('')),
     cfg.StrOpt('user_name', default=('admin'), help=('')),
     cfg.StrOpt('password', default=('secret'), help=('')),
+    cfg.StrOpt('use_bdvif', default=True, help='Use BD-VIF when supported by device firmware'),
 ]
 
 ASR1K_OPTS = [
@@ -130,7 +131,10 @@ def create_device_pair_dictionary():
     for device_name in conf:
         device_dict[device_name] = {}
         for key, value in conf[device_name]:
-            device_dict[device_name][key] = value[0]
+            val = value[0]
+            if key == 'use_bdvif':
+                val = val.lower() == 'true'
+            device_dict[device_name][key] = val
 
     if len(device_dict.keys()) > 2:
         LOG.warning("More than 2 devices were configured, only the first two will be used ")

--- a/asr1k_neutron_l3/models/asr1k_pair.py
+++ b/asr1k_neutron_l3/models/asr1k_pair.py
@@ -53,7 +53,7 @@ class ASR1KContext(ASR1KContextBase):
     version_min_17_3 = property(lambda self: self._get_version_attr('_version_min_17_3'))
     has_stateless_nat = property(lambda self: self._get_version_attr('_has_stateless_nat'))
 
-    def __init__(self, name, host, yang_port, nc_timeout, username, password, insecure=True,
+    def __init__(self, name, host, yang_port, nc_timeout, username, password, use_bdvif, insecure=True,
                  force_bdi=False, headers={}):
         self.name = name
         self.host = host
@@ -61,6 +61,7 @@ class ASR1KContext(ASR1KContextBase):
         self.nc_timeout = nc_timeout
         self.username = username
         self.password = password
+        self._use_bdvif = use_bdvif
         self.insecure = insecure
         self.force_bdi = force_bdi
         self.headers = headers
@@ -95,7 +96,7 @@ class ASR1KContext(ASR1KContextBase):
 
     @property
     def use_bdvif(self):
-        return self.version_min_17_3 and not self.force_bdi
+        return self.version_min_17_3 and self._use_bdvif and not self.force_bdi
 
     def mark_alive(self, alive):
         if not alive:
@@ -126,7 +127,7 @@ class ASR1KPair(object):
             asr1kctx = ASR1KContext(device_name, config.get('host'),
                                     config.get('yang_port', self.config.asr1k_devices.yang_port),
                                     int(config.get('nc_timeout', self.config.asr1k_devices.nc_timeout)),
-                                    config.get('user_name'), config.get('password'),
+                                    config.get('user_name'), config.get('password'), config.get('use_bdvif', True),
                                     insecure=True)
 
             self.contexts.append(asr1kctx)


### PR DESCRIPTION
Add an option to turn off BD-VIF, even when the feature is supported by
the underlying firmware. This feature can be used when running into the
"100 BD-VIFS per BD only" bug until a better solution is available.