### PR TITLE
Disable NTP servers on customer reachable interfaces

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
@@ -57,6 +57,8 @@ class L3Constants(object):
     ACL = "acl"
     ACL_NAME = "acl-name"
     DIRECTION_OUT = "out"
+    NTP = "ntp"
+    NTP_DISABLE = "disable"
 
 
 class VBInterface(NyBase):
@@ -141,6 +143,8 @@ class VBInterface(NyBase):
             {'key': 'access_group_out', 'yang-key': 'acl-name', 'yang-path': 'ip/access-group/out/acl'},
             {'key': 'redundancy_group'},
             {'key': 'shutdown', 'default': False, 'yang-type': YANG_TYPE.EMPTY},
+            {'key': 'ntp_disable', 'yang-key': 'disable', 'yang-path': 'ntp',  'default': False,
+             'yang-type': YANG_TYPE.EMPTY}
         ]
 
     def __init__(self, **kwargs):
@@ -215,6 +219,12 @@ class VBInterface(NyBase):
 
         vbi[L3Constants.IP] = ip
         vbi[L3Constants.VRF] = vrf
+
+        vbi[L3Constants.NTP] = {xml_utils.NS: xml_utils.NS_CISCO_NTP}
+        if self.ntp_disable:
+           vbi[L3Constants.NTP][L3Constants.NTP_DISABLE] = ''
+        else:
+            vbi[L3Constants.NTP][xml_utils.OPERATION] = NC_OPERATION.REMOVE
 
         result = OrderedDict()
         result[context.bd_iftype] = vbi

--- a/asr1k_neutron_l3/models/netconf_yang/xml_utils.py
+++ b/asr1k_neutron_l3/models/netconf_yang/xml_utils.py
@@ -34,6 +34,7 @@ NS_CISCO_ROUTE_MAP = 'http://cisco.com/ns/yang/Cisco-IOS-XE-route-map'
 NS_CISCO_EFP_OPER = 'http://cisco.com/ns/yang/Cisco-IOS-XE-efp-oper'
 NS_CISCO_ARP = 'http://cisco.com/ns/yang/Cisco-IOS-XE-arp'
 NS_CISCO_BRIDGE_DOMAIN = 'http://cisco.com/ns/yang/Cisco-IOS-XE-bridge-domain'
+NS_CISCO_NTP = 'http://cisco.com/ns/yang/Cisco-IOS-XE-ntp'
 NS_IETF_INTERFACE = "urn:ietf:params:xml:ns:yang:ietf-interfaces"
 
 
@@ -64,6 +65,7 @@ class XMLUtils(object):
         NS_CISCO_ARP: None,
         NS_IETF_INTERFACE: None,
         NS_CISCO_BRIDGE_DOMAIN: None,
+        NS_CISCO_NTP: None,
     }
 
     @classmethod

--- a/asr1k_neutron_l3/models/neutron/l3/interface.py
+++ b/asr1k_neutron_l3/models/neutron/l3/interface.py
@@ -131,7 +131,8 @@ class GatewayInterface(Interface):
                                             mac_address=self.mac_address, mtu=self.mtu, vrf=self.vrf,
                                             ip_address=self.ip_address,
                                             secondary_ip_addresses=self.secondary_ip_addresses, nat_outside=True,
-                                            redundancy_group=None, route_map='EXT-TOS', access_group_out='EXT-TOS')
+                                            redundancy_group=None, route_map='EXT-TOS', access_group_out='EXT-TOS',
+                                            ntp_disable=True)
 
     def _nat_address(self):
         ips = self.router_port.get('fixed_ips')
@@ -150,7 +151,8 @@ class InternalInterface(Interface):
                                             mac_address=self.mac_address, mtu=self.mtu, vrf=self.vrf,
                                             ip_address=self.ip_address,
                                             secondary_ip_addresses=self.secondary_ip_addresses,
-                                            nat_inside=True, redundancy_group=None, route_map="pbr-{}".format(self.vrf))
+                                            nat_inside=True, redundancy_group=None, route_map="pbr-{}".format(self.vrf),
+                                            ntp_disable=True)
 
 
 class OrphanedInterface(Interface):


### PR DESCRIPTION
Customers should not be able to consume NTP from this router. Hence, BD interfaces get the corresponding config option to disable the NTP server.