### PR TITLE
Use Integer division for syncloop chunk size

### DIFF
--- a/asr1k_neutron_l3/plugins/l3/agents/asr1k_l3_agent.py
+++ b/asr1k_neutron_l3/plugins/l3/agents/asr1k_l3_agent.py
@@ -535,7 +535,7 @@ class L3ASRAgent(manager.Manager, operations.OperationsMixin, DeviceCleanerMixin
         except oslo_messaging.MessagingTimeout:
             if self.sync_routers_chunk_size > SYNC_ROUTERS_MIN_CHUNK_SIZE:
                 self.sync_routers_chunk_size = max(
-                    self.sync_routers_chunk_size / 2,
+                    self.sync_routers_chunk_size // 2,
                     SYNC_ROUTERS_MIN_CHUNK_SIZE)
                 LOG.error('Server failed to return info for routers in '
                           'required time, decreasing chunk size to: %s',


### PR DESCRIPTION
Py2 / was integer division, Py3 is float. In the syncloop we reduce the
chunk size in certain cases. If we use float division we end up getting
a float in range(), which then dies with a TypeError.