### PR TITLE
Delete wrong BD membership of BD-VIF on BD update

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/ny_base.py
+++ b/asr1k_neutron_l3/models/netconf_yang/ny_base.py
@@ -770,9 +770,11 @@ class NyBase(BulkOperations):
         return self._update(context=context, method=method)
 
     @retry_on_failure()
-    def _update(self, context, method=NC_OPERATION.PATCH, json=None, postflight=False):
-        if len(self._internal_validate(context=context)) > 0:
-            self.preflight(context)
+    def _update(self, context, method=NC_OPERATION.PATCH, json=None, preflight=True, postflight=False,
+                internal_validate=True):
+        if not internal_validate or len(self._internal_validate(context=context)) > 0:
+            if preflight:
+                self.preflight(context)
             if postflight:
                 self.postflight(context, method)
 


### PR DESCRIPTION
When adding a BD-VIF to a BridgeDomain (BD) it must not be member of
another bridge, else YANG cannot add it to the new BD. Therefore we need
to add a preflight check for the BridgeDomain model which checks for all
its member if they are in another BD and if they are remove it from
this BD. This is done without calling the preflight check (as we only
want to delete a membership) and without internal validate (as this
could prevent the update from going out, as a single delete request
might look like "nothing changed" to the driver (which is a different
issue, but hasn't fallen on our foots so far)).

Besides this we also need to look into why the device_cleaner is not
properly cleaning bridge memberships, but in any case doing this on
BD update and not only with a cleaner means that calling a sync on a
router (and the regular syncloop can fix this problem).

This problem can happen if for example a delete call fails because YANG
is locking us out again and all retries have been exceeded.