### PR TITLE
Clean VBInterface even when router id still exists

### DIFF
--- a/asr1k_neutron_l3/common/utils.py
+++ b/asr1k_neutron_l3/common/utils.py
@@ -56,10 +56,8 @@ def uuid_to_vrf_id(uuid):
 
 
 def vrf_id_to_uuid(id):
-    if id is None or isinstance(id, str):
-        return False
-
-    if re.match("[0-9a-f]{32}", id):
+    if isinstance(id, str) and \
+        re.match("[0-9a-f]{32}", id):
         return "{}-{}-{}-{}-{}".format(id[0:8], id[8:12], id[12:16], id[16:20], id[20:32])
     return False
 

--- a/asr1k_neutron_l3/models/netconf_yang/bulk_operations.py
+++ b/asr1k_neutron_l3/models/netconf_yang/bulk_operations.py
@@ -88,6 +88,9 @@ class BulkOperations(xml_utils.XMLUtils):
 
         return False
 
+    def is_reassigned(self, queried):
+        return False
+    
     @property
     def neutron_router_id(self):
         return None

--- a/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
@@ -293,15 +293,15 @@ class VBInterface(NyBase):
 
     def is_orphan(self, all_router_ids, all_segmentation_ids, all_bd_ids, context):
         # An interface is an orphan if ALL of these conditions are met
-        #   * it does not belong to any VRF or the router does not exist anymore
         #   * ID is in neutron namespace
         #   * its ID is not referenced in the extra atts table
-        # We don't delete vrf-less interfaces that are in the extra atts table as they could be reused
-        # while we're deleting them
-        return ((self.neutron_router_id and self.neutron_router_id not in all_router_ids) or
-                not self.neutron_router_id) and \
-            self.in_neutron_namespace and \
+        # We can now delete vrf-less interfaces that are in the extra atts table as we
+        # key the delete in the with help of _is_reassigned to the VRF
+        return self.in_neutron_namespace and \
             int(self.name) not in all_bd_ids
+
+    def is_reassigned(self, queried):
+        return self.vrf != queried.vrf
 
 
 class VBISecondaryIpAddress(NyBase):

--- a/asr1k_neutron_l3/plugins/l3/agents/device_cleaner.py
+++ b/asr1k_neutron_l3/plugins/l3/agents/device_cleaner.py
@@ -137,6 +137,17 @@ class DeviceCleanerMixin(object):
                                     if item is None:
                                         raise ValueError("Entity {} {} not present on device {}"
                                                          .format(entity_cls.__name__, stub.id, context.name))
+                                    # This check is done in order to make sure the object fetched from the device in (1)
+                                    # has not been reassigned after (2) to another entity with the same primary key.
+                                    # Assume we find a BD-VIF ID in (1) on the device, (2) finds out it has been removed
+                                    # from extra_atts. While (3) is in progress we reassign it in another thread. We would
+                                    # then later delete it. Hence we check if the item from _interal_get was found with a
+                                    # different attribute, i.e. VRF.
+                                    if stub.is_reassigned(item):
+                                        LOG.info("Entity {} {} on device {}"
+                                            " has been reassigned to another router, skipping cleanup"
+                                            .format(entity_cls.__name__, stub.id, context.name))
+                                        continue
                                     item._delete_no_retry(context=context)
                                     orphan_deleted_count += 1
                                 except RPCError as e:


### PR DESCRIPTION
The cleanup-loop works in 3 steps: It (1) fetches the config objects
from the device, then (2) fetches all relevant objects from the
neutron-server and (3) deletes the objects from the device that it
gathered in (1) but could not find in (2). Object are considered to be
matching if their primary key (in this case BD-VIF ID) matches. Imagine,
a BD-VIF ID was fetched from the device in (1) assigned to VRF A, not
fetched in (2), reassigned after (2) to another VRF. We would then
delete that BD-VIF and break traffic.

In order to prevent this race-condition of deleting a reassigned BD-VIF,
we only delete BD-VIFs if their VRF has been deleted as well. That leads
to a condition, that BD-VIFs could be left orphan, if their VRF is still
existing.

With this PR, we remove the check if a VRF is still existing, so the
BD-VIF will be cleaned up regardless. To prevent the reassignment
race-condition, we fetch the BD-VIF again, lines before it’s deletion
and check if it has been reassigned in the meantime. In this case, do we
still find it assigned to the same VRF seen in (1) than seen now. Hence,
we decrease the time frame in which a race-condition could be happening
to likely milliseconds, subsequently we will only break ports that were
working for milliseconds.
