### PR TITLE
Make sure eventlet is patched on ncc connect

### DIFF
--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -13,6 +13,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import os
+
+if not os.environ.get('DISABLE_EVENTLET_PATCHING'):
+    import eventlet
+    eventlet.monkey_patch()
 
 import datetime
 from retrying import retry


### PR DESCRIPTION
With Neutron Ussuri we sometimes get a RuntimeError from eventlet that
suggests a double read on a socket is happening by different threads.
We want to make sure that when we use ncclient that eventlet is patched.
Therefore as a possible mitigation call again eventlet.monkey_patch(),
just if the asr1k driver was not used by first importing the
asr1k_l3_agent or asr1k_ml2_agent.