### PR TITLE
Use patched ncclient for compatibility with eventlet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ osc-lib>=1.8.0 # Apache-2.0
 retrying >=1.3.3
 prometheus_client>=0.0.19
 bs4>=0.0.1
-ncclient
+ncclient==0.6.12+sapcc
 networking_bgpvpn>=11.0.0


### PR DESCRIPTION
the +sapcc version is build from https://github.com/sapcc/ncclient/tree/v0.6.12+sapcc and
is available via the inhouse pypi repository.