### PR TITLE
Add self control of aged connections.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/C5322389/Work/src/neutron/.tox/venv/bin/python"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/C5322389/Work/src/neutron/.tox/venv/bin/python"
+}

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -194,7 +194,8 @@ class YangConnection(object):
 
     @property
     def is_aged(self):
-        return self.max_age > 0 and self.age > self.max_age
+        # return self.max_age > 0 and self.age > self.max_age
+        return self.max_age > 0 and self.age > 360
 
     @property
     def connection(self):
@@ -202,7 +203,7 @@ class YangConnection(object):
             if self.is_inactive:
                 LOG.debug("Existing session id {} is not active, closing and reconnecting".format(self.session_id))
                 self._reconnect()
-            if self.is_aged:
+            if self.is_aged and self.lock.locked():
                 LOG.debug("Existing session id {} is aged (max lifetime: {}, session aged: {:10.2f}s), closing and "
                           "reconnecting".format(self.session_id, self.max_age, self.age))
                 self._reconnect()

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -245,7 +245,12 @@ class YangConnection(object):
         except TransportError:
             pass
         finally:
-            self._ncc_connection = self._connect(self.context)
+            try:
+                self._ncc_connection = self._connect(self.context)
+            except RuntimeError as e:
+                # Catch the error "Second simultaneous read" when ncclient transport was not closed properly.
+                LOG.warning(
+                    "Failed to re-connect due to '{}', connection will be attempted again in the next call".format(e))
 
     def _connect(self, context):
         port = context.yang_port

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -39,6 +39,7 @@ from oslo_log import log as logging
 from oslo_service import loopingcall
 
 import paramiko
+from eventlet.pools import Pool
 from ncclient.operations.errors import TimeoutExpiredError
 from ncclient.operations import util
 from ncclient.transport.errors import SSHError
@@ -143,11 +144,7 @@ class ConnectionPool(object):
             LOG.info("Initializing connection pool with yang pool size {}".format(self.yang_pool_size))
 
             for context in self.pair_config.contexts:
-                yang = []
-
-                for i in range(self.yang_pool_size):
-                    yang.append(YangConnection(
-                        context, id=i, max_age=max_age))
+                yang = Pool(create=lambda: YangConnection(context, max_age=max_age), max_size=self.yang_pool_size)
 
                 self.devices[context.host] = yang
 
@@ -155,35 +152,17 @@ class ConnectionPool(object):
         except Exception as e:
             LOG.exception(e)
 
-    @retry(stop_max_attempt_number=25, wait_fixed=100, retry_on_exception=_retry_if_exhausted)
     def pop_connection(self, context=None):
         pool = self.devices.get(context.host)
-        connection = None
-        if len(pool) > 0:
-            connection = pool.pop(0)
 
-        if connection is None:
+        if pool.free() == 0:
             PrometheusMonitor().connection_pool_exhausted.labels(device=context.host).inc()
-            raise ConnectionPoolExhausted()
 
-        connection.lock.acquire()
-
-        return connection
+        return pool.get()
 
     def push_connection(self, connection, context=None):
-        connection.lock.release()
-
         pool = self.devices.get(context.host)
-        pool.append(connection)
-
-    def get_connection(self, context):
-        connection = self.devices.get(context.host).pop(0)
-        self.devices.get(context.host).append(connection)
-
-        if connection is None:
-            raise Exception('No connection can be found for {}'.format(context.host))
-
-        return connection
+        pool.put(connection)
 
 
 class YangConnection(object):

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -220,8 +220,7 @@ class YangConnection(object):
 
     def _reconnect(self):
         try:
-            with self.lock:
-                self.close()
+            self.close()
         except TransportError:
             pass
         finally:

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -215,8 +215,7 @@ class YangConnection(object):
 
     @property
     def is_aged(self):
-        # return self.max_age > 0 and self.age > self.max_age
-        return self.max_age > 0 and self.age > 360
+        return self.max_age > 0 and self.age > self.max_age
 
     @property
     def connection(self):

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -240,7 +240,7 @@ class YangConnection(object):
 
     def _reconnect(self):
         try:
-            with self.lock():
+            with self.lock:
                 self.close()
         except TransportError:
             pass

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -219,7 +219,8 @@ class YangConnection(object):
 
     def _reconnect(self):
         try:
-            self.close()
+            with self.lock:
+                self.close()
         except TransportError:
             pass
         finally:

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -39,7 +39,6 @@ from oslo_log import log as logging
 from oslo_service import loopingcall
 
 import paramiko
-import eventlet
 from ncclient.operations.errors import TimeoutExpiredError
 from ncclient.operations import util
 from ncclient.transport.errors import SSHError
@@ -229,11 +228,6 @@ class YangConnection(object):
                 LOG.debug("Existing session id {} is aged (max lifetime: {}, session aged: {:10.2f}s), closing and "
                           "reconnecting".format(self.session_id, self.max_age, self.age))
                 self._reconnect()
-        except RuntimeError as e:
-            LOG.warning("Catch second simultaneous read")
-            eventlet.debug.hub_listener_stacks(state=True)
-            print(eventlet.debug.format_hub_listeners())
-            LOG.exception(e)
         except Exception as e:
             if isinstance(e, TimeoutExpiredError) or isinstance(e, SSHError) or isinstance(e, SessionCloseError):
                 LOG.warning(

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -240,8 +240,7 @@ class YangConnection(object):
 
     def _reconnect(self):
         try:
-            with self.lock:
-                self.close()
+            self.close()
         except TransportError:
             pass
         finally:

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -39,6 +39,7 @@ from oslo_log import log as logging
 from oslo_service import loopingcall
 
 import paramiko
+import eventlet
 from ncclient.operations.errors import TimeoutExpiredError
 from ncclient.operations import util
 from ncclient.transport.errors import SSHError
@@ -228,6 +229,11 @@ class YangConnection(object):
                 LOG.debug("Existing session id {} is aged (max lifetime: {}, session aged: {:10.2f}s), closing and "
                           "reconnecting".format(self.session_id, self.max_age, self.age))
                 self._reconnect()
+        except RuntimeError as e:
+            LOG.warning("Catch second simultaneous read")
+            eventlet.debug.hub_listener_stacks(state=True)
+            print(eventlet.debug.format_hub_listeners())
+            LOG.exception(e)
         except Exception as e:
             if isinstance(e, TimeoutExpiredError) or isinstance(e, SSHError) or isinstance(e, SessionCloseError):
                 LOG.warning(


### PR DESCRIPTION
This commit removes a special greenthread for checking aged connections and adds self-control system for each connection. The connection age will be checked every time before using and if the connection is out of date we will reconnect to the device. These changes should resolve the error `Second simultaneous read` raised in eventlet.