### PR TITLE
start_rpc_listeners should be called by service worker, not on initialization

### DIFF
--- a/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
@@ -60,7 +60,6 @@ class ASR1KRouterPlugin(l3_extension_adapter.ASR1KPluginBase, base.ServicePlugin
         asr1k_config.register_l3_opts()
 
         self.add_periodic_l3_agent_status_check()
-        self.start_rpc_listeners()
 
     @log_helpers.log_method_call
     def start_rpc_listeners(self):

--- a/asr1k_neutron_l3/plugins/ml2/drivers/mech_asr1k/driver.py
+++ b/asr1k_neutron_l3/plugins/ml2/drivers/mech_asr1k/driver.py
@@ -19,6 +19,7 @@ from neutron_lib import constants as p_constants
 from neutron_lib import context as n_context
 from neutron_lib.plugins.ml2 import api
 from neutron_lib import rpc as n_rpc
+from neutron import service
 from neutron.plugins.ml2.drivers import mech_agent
 from oslo_config import cfg
 from oslo_log import helpers as log_helpers
@@ -52,8 +53,6 @@ class ASR1KMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         super(ASR1KMechanismDriver, self).__init__(self.agent_type, self.vif_type, self.vif_details)
         self.db = asr1k_db.get_db_plugin()
 
-        self.start_rpc_listeners()
-
         LOG.info("ASR mechanism driver initialized.")
 
     def _setup_rpc(self):
@@ -61,6 +60,9 @@ class ASR1KMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         self.endpoints = [
             rpc_api.ASR1KPluginCallback()
         ]
+
+    def get_workers(self):
+        return [service.RpcWorker([self], worker_process_count=0)]
 
     @log_helpers.log_method_call
     def start_rpc_listeners(self):


### PR DESCRIPTION
start_rpc_listeners is usally called by a neutron.service.RpcWorker which is collected
by the neutron.service Manager. ML2 Plugins can provide their start_rpc_listener callback by returning
it via the ml2 mechanism get_workers() callback.

Why?
1. it's the neutron/openstack way to register the RPC consumer workers.
2. this way it honors the wsgi script that doesn't want the RPC consumers
to spawn, they should soley be handeled by the rpc-server.