### PR TITLE
Honor adv. extra routes flag for bgpvpn

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -215,9 +215,10 @@ class Router(Base):
 
     def _build_bgp_address_family(self):
         networks_v4 = self.get_internal_cidrs()
-        for router_route in self.routes.routes:
-            if router_route.cidr != "0.0.0.0/0":
-                networks_v4.append(router_route.cidr)
+        if self.router_info["bgpvpn_advertise_extra_routes"]:
+            for router_route in self.routes.routes:
+                if router_route.cidr != "0.0.0.0/0":
+                    networks_v4.append(router_route.cidr)
 
         return bgp.AddressFamily(self.router_info.get('id'), asn=self.config.asr1k_l3.fabric_asn,
                                  routable_interface=self.routable_interface,

--- a/asr1k_neutron_l3/plugins/db/asr1k_db.py
+++ b/asr1k_neutron_l3/plugins/db/asr1k_db.py
@@ -86,6 +86,15 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
         query = query.distinct()
         return query.all()
 
+    def get_bgpvpn_advertise_extra_routes_by_router_id(self, context, router_id):
+        """Advertise route mode for bgpvpn - only False if all router associations have this turned off"""
+        query = context.session.query(bgpvpn_db.BGPVPNRouterAssociation.advertise_extra_routes)
+        query = query.filter(bgpvpn_db.BGPVPNRouterAssociation.router_id == router_id)
+        for entry in query.all():
+            if entry.advertise_extra_routes:
+                return True
+        return False
+
     def ensure_snat_mode(self, context, port_id, mode):
         if port_id is None:
             LOG.warning("Asked to ensure SNAT mode for port==None, can't do anything.")

--- a/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
@@ -255,6 +255,10 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
             rt_import = []
             rt_export = []
             bgpvpns = self.db.get_bgpvpns_by_router_id(context, router['id'])
+            router["bgpvpn_advertise_extra_routes"] = True
+            if bgpvpns:
+                adv_mode = self.db.get_bgpvpn_advertise_extra_routes_by_router_id(context, router['id'])
+                router["bgpvpn_advertise_extra_routes"] = adv_mode
 
             for bgpvpn in bgpvpns:
                 if bgpvpn.route_targets:


### PR DESCRIPTION
By default BGPVPNs advertise all router_routes. BGPVPNRouterAssociation
have a flag that controls this behavior, but we can only turn this off
when all associations have this flag turned off.