### PR TITLE
AZ aware router scheduling

### DIFF
--- a/asr1k_neutron_l3/common/asr1k_constants.py
+++ b/asr1k_neutron_l3/common/asr1k_constants.py
@@ -32,3 +32,5 @@ ROUTER_STATE_ERROR = 'ERROR'
 
 SNAT_MODE_POOL = 'pool'
 SNAT_MODE_INTERFACE = 'interface'
+
+NO_AZ_LIST = (None, 'nova')

--- a/asr1k_neutron_l3/common/asr1k_exceptions.py
+++ b/asr1k_neutron_l3/common/asr1k_exceptions.py
@@ -103,3 +103,11 @@ class CapabilityNotFoundException(DeviceOperationException):
 
 class VersionInfoNotAvailable(DeviceOperationException):
     message = "Could not get version info for attribute %(entity)s from host %(host)s"
+
+
+class OnlyOneAZHintAllowed(nexception.BadRequest):
+    message = "Only one availability zone hint allowed per object"
+
+
+class RouterNetworkAZMismatch(nexception.NeutronException):
+    message = "AZ hint of router and network do not match (router is in %(router_az)s, network in %(network_az)s)"

--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -44,6 +44,13 @@ ASR1K_OPTS = [
     cfg.BoolOpt('trace_yang_call_failures', default=False,
                 help=_("Log all failed YANG xml calls, including how long they took")),
 
+    cfg.BoolOpt('ignore_invalid_az_hint_for_router', default=False,
+                help="Router AZ hints will not be validated. This means that an AZ hint is accepted even if no asr1k "
+                     "agent is present with this AZ. This will also disable proper scheduling. ALL routers will "
+                     "be scheduled to any router of the driver's liking if no candidate with a matching AZ hint "
+                     "is present."),
+    cfg.BoolOpt('ignore_router_network_az_hint_mismatch', default=False,
+                help="Do not abort operation if router and network AZ hint do not match."),
 ]
 
 ASR1K_L3_OPTS = [
@@ -95,13 +102,6 @@ AGENT_STATE_OPTS = [
                 help=_('Log agent heartbeats')),
 ]
 
-AVAILABILITY_ZONE_OPTS = [
-    # The default AZ name "nova" is selected to match the default
-    # AZ name in Nova and Cinder.
-    cfg.StrOpt('availability_zone', max_length=255, default='nova',
-               help=_("Availability zone of this node")),
-]
-
 
 def create_device_pair_dictionary():
     device_dict = {}
@@ -139,19 +139,20 @@ def create_address_scope_dict():
     return address_scope_dict
 
 
-def register_l3_opts():
+def register_common_opts():
     cfg.CONF.register_opts(ASR1K_OPTS, "asr1k")
+    cfg.CONF.register_opts(AGENT_STATE_OPTS, 'AGENT')
+    common.register_availability_zone_opts_helper(cfg.CONF)
+
+
+def register_l3_opts():
     cfg.CONF.register_opts(ASR1K_L3_OPTS, "asr1k_l3")
     cfg.CONF.register_opts(ASR1K_L2_OPTS, "asr1k_l2")
-    cfg.CONF.register_opts(AGENT_STATE_OPTS, 'AGENT')
-    cfg.CONF.register_opts(AVAILABILITY_ZONE_OPTS, 'AGENT')
     common.register_interface_opts()
     common.register_interface_driver_opts_helper(cfg.CONF)
 
 
 def register_l2_opts():
-    cfg.CONF.register_opts(AGENT_STATE_OPTS, 'AGENT')
-    cfg.CONF.register_opts(ASR1K_OPTS, "asr1k")
     cfg.CONF.register_opts(ASR1K_L2_OPTS, "asr1k_l2")
     cfg.CONF.register_opts(service.RPC_EXTRA_OPTS)
 

--- a/asr1k_neutron_l3/plugins/l3/agents/asr1k_l3_agent.py
+++ b/asr1k_neutron_l3/plugins/l3/agents/asr1k_l3_agent.py
@@ -85,6 +85,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 def main(manager='asr1k_neutron_l3.plugins.l3.agents.asr1k_l3_agent.L3ASRAgentWithStateReport'):
+    asr1k_config.register_common_opts()
     asr1k_config.register_l3_opts()
     common_config.init(sys.argv[1:])
     common_config.setup_logging()

--- a/asr1k_neutron_l3/plugins/l3/schedulers/simple_asr1k_scheduler.py
+++ b/asr1k_neutron_l3/plugins/l3/schedulers/simple_asr1k_scheduler.py
@@ -15,9 +15,11 @@
 #    under the License.
 
 from neutron.scheduler import l3_agent_scheduler
+from oslo_config import cfg
 from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
 
+from asr1k_neutron_l3.common import asr1k_constants as asr1k_const
 
 LOG = logging.getLogger(__name__)
 
@@ -43,12 +45,27 @@ class SimpleASR1KScheduler(l3_agent_scheduler.AZLeastRoutersScheduler):
                            'agent_id': current_l3_agents[0]['id']})
                 return []
 
-            candidates = plugin.get_l3_agents(context, active=True)
+            orig_candidates = plugin.get_l3_agents(context, active=True)
+
+            # router creation with az hint: only schedule on agent with appropriate AZ
+            # router creation without az hint: only schedule on agent with no AZ
+            az_hints = orig_az_hints = self._get_az_hints(sync_router)
+            if not az_hints or az_hints[0] in asr1k_const.NO_AZ_LIST:
+                az_hints = asr1k_const.NO_AZ_LIST
+            candidates = [c for c in orig_candidates if c.availability_zone in az_hints]
+
+            if not candidates and orig_az_hints and cfg.CONF.asr1k.ignore_invalid_az_hint_for_router:
+                LOG.warning("No candidate found for router %s with az hint %s, reverting to original candidate list %s",
+                            sync_router['id'], az_hints, orig_candidates)
+                candidates = orig_candidates
+
             if not candidates:
-                LOG.warning('No active L3 agents')
+                LOG.warning('No active L3 agents found for router %s (az hints were %s)',
+                            sync_router['id'], orig_az_hints)
                 return []
 
-            LOG.info(candidates)
+            LOG.info("Found following candidates for router %s: %s",
+                     sync_router['id'], ", ".join(c.host for c in candidates))
 
             return candidates
 

--- a/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
@@ -56,6 +56,7 @@ class ASR1KRouterPlugin(l3_extension_adapter.ASR1KPluginBase, base.ServicePlugin
 
         self.router_scheduler = importutils.import_object(cfg.CONF.router_scheduler_driver)
 
+        asr1k_config.register_common_opts()
         asr1k_config.register_l2_opts()
         asr1k_config.register_l3_opts()
 

--- a/asr1k_neutron_l3/plugins/ml2/agents/asr1k_ml2_agent.py
+++ b/asr1k_neutron_l3/plugins/ml2/agents/asr1k_ml2_agent.py
@@ -66,6 +66,7 @@ SYNC_ROUTERS_MIN_CHUNK_SIZE = 32
 
 def main():
     common_config.init(sys.argv[1:])
+    asr1k_config.register_common_opts()
     asr1k_config.register_l2_opts()
     common_config.setup_logging()
     eventlet_backdoor.initialize_if_enabled(cfg.CONF)
@@ -113,6 +114,7 @@ class ASR1KNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
         self.agent_state = {
             'binary': 'asr1k-ml2-agent',
             'host': self.conf.host,
+            'availability_zone': CONF.AGENT.availability_zone,
             'topic': n_const.L2_AGENT_TOPIC,
             'configurations': {
 


### PR DESCRIPTION
When a router is scheduled with an AZ hint it will only be scheduled
onto an asr1k agent with that given AZ, otherwise it will be scheduled
onto an agent without an AZ set. None and 'nova' (the default AZ) are
both regarded as "no AZ set". Only a single AZ hint is allowed per
router.

A router now also checks if a network has an AZ set on router attach. If
the network has a hint but the router does not then association is
denied.

Agents now properly advertise their given AZ. The ML2 agent does not use
this information at the moment, as for ml2/portbinding AZ restrictions
will be enforced by a driver above the asr1k driver.

WIP, as I still need to do a proper codereview and also the flags to
declaw this are missing (i.e. we have the code ready, but not the
hardware and suddenly everything with AZ hint starts failing to get
deployed).