### PR TITLE
Allow to overwrite default route via extra routes

### DIFF
--- a/asr1k_neutron_l3/common/asr1k_constants.py
+++ b/asr1k_neutron_l3/common/asr1k_constants.py
@@ -34,3 +34,6 @@ SNAT_MODE_POOL = 'pool'
 SNAT_MODE_INTERFACE = 'interface'
 
 NO_AZ_LIST = (None, 'nova')
+
+TAG_DEFAULT_ROUTE_OVERWRITE = 'custom-default-route'
+TAG_SKIP_MONITORING = 'skip-monitoring'


### PR DESCRIPTION
If a customer in the past configured a default route it was up to the
yang stack which route would be programmed, the openstack one pointing
to the real northbound gateway or the customers overwrite. This allows
explicitly overwritten default routes and removes the openstack default
route from the yang request.
Once a default route was overwritten, outbound connectivity for all
networks on that router will be broken, hence we set a tag indicating to
skip the monitoring. The namespace prober will be extended to make use
of this tag.