### PR TITLE
Apply different route-map on DAPnet extra routes

### DIFF
--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -74,6 +74,8 @@ ASR1K_L3_OPTS = [
                help="Route-Map prefix for Directly Accessible Private Networks (DAPNets)"),
     cfg.StrOpt('dapnet_network_rm', default='RM-DAP',
                help="Route-Map to apply to all DAPNet BGP network statements"),
+    cfg.StrOpt('dapnet_extra_routes_rm', default='RM-DAP-EXTRA-ROUTES',
+               help="Route-Map to apply to all BGP network statements for extra routes that are contained in a DAPNet"),
 ]
 
 ASR1K_L2_OPTS = [

--- a/asr1k_neutron_l3/models/neutron/l3/bgp.py
+++ b/asr1k_neutron_l3/models/neutron/l3/bgp.py
@@ -22,7 +22,8 @@ from asr1k_neutron_l3.models.neutron.l3 import base
 
 
 class AddressFamily(base.Base):
-    def __init__(self, vrf, asn=None, routable_interface=False, rt_export=[], networks_v4=[], routable_networks=[]):
+    def __init__(self, vrf, asn=None, routable_interface=False, rt_export=[],
+                 connected_cidrs=[], routable_networks=[], extra_routes=[]):
         super(AddressFamily, self).__init__()
         self.vrf = utils.uuid_to_vrf_id(vrf)
         self.routable_interface = routable_interface
@@ -32,11 +33,14 @@ class AddressFamily(base.Base):
         self.routable_networks = routable_networks
         self.networks_v4 = set()
 
-        for net in networks_v4:
+        for net in connected_cidrs + extra_routes:
             # rm is applied to all routable networks and their subnets
             rm = None
             if any(utils.network_in_network(net, routable_network) for routable_network in routable_networks):
-                rm = cfg.CONF.asr1k_l3.dapnet_network_rm
+                if net in extra_routes:
+                    rm = cfg.CONF.asr1k_l3.dapnet_extra_routes_rm
+                else:
+                    rm = cfg.CONF.asr1k_l3.dapnet_network_rm
 
             net = bgp.Network.from_cidr(net, rm)
             self.networks_v4.add(net)

--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -214,16 +214,16 @@ class Router(Base):
         return False
 
     def _build_bgp_address_family(self):
-        networks_v4 = self.get_internal_cidrs()
+        connected_cidrs = self.get_internal_cidrs()
+        extra_routes = list()
         if self.router_info["bgpvpn_advertise_extra_routes"]:
-            for router_route in self.routes.routes:
-                if router_route.cidr != "0.0.0.0/0":
-                    networks_v4.append(router_route.cidr)
+            extra_routes = [x.cidr for x in self.routes.routes if x.cidr != "0.0.0.0/0"]
 
         return bgp.AddressFamily(self.router_info.get('id'), asn=self.config.asr1k_l3.fabric_asn,
                                  routable_interface=self.routable_interface,
-                                 rt_export=self.rt_export, networks_v4=networks_v4,
-                                 routable_networks=self.get_routable_networks())
+                                 rt_export=self.rt_export, connected_cidrs=connected_cidrs,
+                                 routable_networks=self.get_routable_networks(),
+                                 extra_routes=extra_routes)
 
     def _build_dynamic_nat(self):
         pool_nat = nat.DynamicNAT(self.router_id, gateway_interface=self.gateway_interface,


### PR DESCRIPTION
Turns out _network devices_ that aggregate prefixes start to generate a
null0 static route as soon as any longer prefix than the aggregate is
present, even when a prefix with equal length as the aggregate is also
received via BGP the null0 route is still installed.

In Neutron, if a DAPnet enabled router chooses to add a static route
with a longer sized prefix, this prefix will lead to any BGP upstream
device installing the aggregates null0 route and the more specific
prefix for which a static route was just created. Due to the null0
route, connectivity will be lost to anything not contained in the static
route but contained in the larger null0 route.

To work around, we impose another route-map on static routes that pushes
a different community on the route. That community in turn we use again
to filter it out when announcing northbound to ACI.