### PR TITLE
Throw API error if a networks segment exceeds the BD-VIF limit

### DIFF
--- a/asr1k_neutron_l3/common/asr1k_exceptions.py
+++ b/asr1k_neutron_l3/common/asr1k_exceptions.py
@@ -29,6 +29,11 @@ class SecondDot1QPoolExhausted(nexception.NotFound):
     message = "No free second dot1q id could be allocated for agent host %(agent_host)s."
 
 
+class BdVifInBdExhausted(nexception.Conflict):
+    message = ("Network %(network_id)s cannot be bound to router %(router_id)s due to BD-VIF hardware limit exceeded. "
+               "Please chose another network.")
+
+
 class DeviceUnreachable(BaseException):
     message = "Device %(host)s is not reachable"
 

--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -92,7 +92,8 @@ ASR1K_L2_OPTS = [
     cfg.IntOpt('sync_chunk_size', default=10, help=_("Number of ports to process in on poll")),
     cfg.StrOpt('external_interface', default=('1'), help=('')),
     cfg.StrOpt('loopback_external_interface', default=('2'), help=('')),
-    cfg.StrOpt('loopback_internal_interface', default=('3'), help=(''))
+    cfg.StrOpt('loopback_internal_interface', default=('3'), help=('')),
+    cfg.IntOpt('bdvif_bd_limit', default=100, help='Hardware limit of BD-VIF per Bridge Domain'),
 ]
 
 AGENT_STATE_OPTS = [

--- a/asr1k_neutron_l3/plugins/l3/schedulers/simple_asr1k_scheduler.py
+++ b/asr1k_neutron_l3/plugins/l3/schedulers/simple_asr1k_scheduler.py
@@ -64,6 +64,15 @@ class SimpleASR1KScheduler(l3_agent_scheduler.AZLeastRoutersScheduler):
                             sync_router['id'], orig_az_hints)
                 return []
 
+            # Make sure the candidates do not reach the platforms hardware limit of BD-VIFs per BD
+            external_network_id = sync_router['external_gateway_info']['network_id']
+            agents_port_count = plugin.db.get_network_port_count_per_agent(context, external_network_id)
+            candidates = [c for c in candidates if agents_port_count.get(c.host, 0) < cfg.CONF.asr1k_l2.bdvif_bd_limit]
+            if not candidates:
+                LOG.warning(f'No L3 agents available that satisfy the BD-VIF '
+                            f'hardware limit for network {external_network_id}')
+                return []
+
             LOG.info("Found following candidates for router %s: %s",
                      sync_router['id'], ", ".join(c.host for c in candidates))
 


### PR DESCRIPTION
The ASR/Catalyst router platform has a limit that does not allow more
than 100 BD-VIFs per bridge-domain, or in our OpenStack setup more than
100 ports in an ASR bound segment. As we cannot work around that, we
will now raise an API exception and tell the user that we cannot assign
that network.

We also take care of this on scheduling in case some of the hardware
routers/agents are above limit while others are not.