### PR TITLE
Support snat_enabled wit hl3-ext-gw-mode

### DIFF
--- a/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 from neutron_lib.agent import topics
+from neutron_lib.api.definitions import l3_ext_gw_mode
 from neutron_lib import constants as n_const
 from neutron_lib.plugins import constants as plugin_constants
 from neutron_lib import rpc as n_rpc
@@ -38,6 +39,7 @@ class ASR1KRouterPlugin(l3_extension_adapter.ASR1KPluginBase, base.ServicePlugin
                                    "extraroute",
                                    "l3_agent_scheduler",
                                    "router_availability_zone",
+                                   l3_ext_gw_mode.ALIAS,
                                    "asr1k_operations"]
 
     def __init__(self):


### PR DESCRIPTION
By showing that our router plugin supports the l3-ext-gw-mode we can
allow the user to change snat_enabled attribute on a router. If we don't
advertise this as supported the user will just get an error:

Invalid input for external_gateway_info. Reason: Unexpected keys
supplied: enable_snat.