### PR TITLE
Use different namespace_separator with new libexpat

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/xml_utils.py
+++ b/asr1k_neutron_l3/models/netconf_yang/xml_utils.py
@@ -70,7 +70,7 @@ class XMLUtils(object):
 
     @classmethod
     def to_raw_json(cls, xml):
-        return xmltodict.parse(xml, process_namespaces=True, namespaces=cls.namespaces)
+        return xmltodict.parse(xml, process_namespaces=True, namespaces=cls.namespaces, namespace_separator=' ')
 
     @classmethod
     def to_json(cls, xml, context):


### PR DESCRIPTION
Newer version of libexpat have a mitigation for CVE-2022-25236 in place,
which disallows the use of certain characters as namespace separators
(to my understanding this is the separator used to separate namespace
and tag name in the parsed xml output we receive from the library). We
implicitly use libexpat via xmltodict.parse(), xmltodict uses a default
of ':', which now is invalid. Using ':' as separator results in the
following exception:

xml.parsers.expat.ExpatError: out of memory: line 1, column 0

This can also be reproduced with this python snippet:

xmltodict.parse("<foo></foo>", process_namespaces=True)

To mitigate this we need to use a different separator. xmltodict.parse()
exposes this as an argument, so passing namespace_separator=' ' (as
recommended by libexpat as a char that is not part of an url, see bug
reports below or CVE) solves the problem for us. From what I can see
this also doesn't require any other changes on our side.

Relevant change in libexpat:
 * https://github.com/libexpat/libexpat/pull/561

Relevant bugreports:
 * https://github.com/libexpat/libexpat/issues/572
 * https://github.com/martinblech/xmltodict/issues/289