### PR TITLE
Use replace instead of merge for prefix lists

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/prefix.py
+++ b/asr1k_neutron_l3/models/netconf_yang/prefix.py
@@ -16,7 +16,7 @@
 
 from collections import OrderedDict
 
-from asr1k_neutron_l3.models.netconf_yang.ny_base import NyBase
+from asr1k_neutron_l3.models.netconf_yang.ny_base import execute_on_pair, NC_OPERATION, NyBase
 from asr1k_neutron_l3.common import utils
 
 
@@ -104,11 +104,12 @@ class Prefix(NyBase):
             seq.no = (len(self.seq) + 1) * 10
         self.seq.append(seq)
 
-    def update(self):
+    @execute_on_pair()
+    def update(self, context):
         if len(self.seq) > 0:
-            return super(Prefix, self).update()
+            return super(Prefix, self)._update(context=context, method=NC_OPERATION.PUT)
         else:
-            return super(Prefix, self).delete()
+            return super(Prefix, self)._delete(context=context)
 
     def to_dict(self, context):
         prefix = OrderedDict()


### PR DESCRIPTION
When a prefix list has multiple members and these members change (e.g.
by removing a subnet from a network) the driver might not be able to
reach the desired config state. Old rules might stay, rules might not be
properly replaced, we might end up with the same rules multiple times
(but with different seqs) on the device. Therefore we now use replace
(aka PUT) instead of merge.