### PR TITLE
[yoga] neutron callback system passing dbevent payload instead of context, router_id, network_id

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -2,7 +2,7 @@ name: run-tox
 on:
   push:
     branches:
-      - stable/ussuri-m3
+      - stable/yoga-m3
   pull_request:
 jobs:
   build:

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6]
+        python: [3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
@@ -144,7 +144,12 @@ class L3RpcNotifierMixin(object):
 
     @registry.receives(resources.ROUTER_INTERFACE, [events.BEFORE_CREATE])
     @log_helpers.log_method_call
-    def _check_internal_net_az_hints(self, resource, event, trigger, context, router_id, network_id, **kwargs):
+    def _check_internal_net_az_hints(self, resource, event, trigger, payload, **kwargs):
+
+        router_id = payload.resource_id
+        network_id = payload.metadata.get("network_id")
+        context = payload.context
+
         LOG.debug("(AZ check) router interface before_create hook for router %s network %s",
                   router_id, network_id)
         plugin = directory.get_plugin()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ retrying >=1.3.3
 prometheus_client>=0.0.19
 bs4>=0.0.1
 ncclient
-networking_bgpvpn @ git+https://github.com/sapcc/networking-bgpvpn@stable/yoga-m3
+networking-bgpvpn @ git+https://github.com/sapcc/networking-bgpvpn@stable/yoga-m3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ retrying >=1.3.3
 prometheus_client>=0.0.19
 bs4>=0.0.1
 ncclient
-networking_bgpvpn>=11.0.0
+networking_bgpvpn @ git+https://github.com/sapcc/networking-bgpvpn@stable/yoga-m3

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,10 @@ skipsdist = True
 usedevelop = True
 install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
-         PYTHONWARNINGS=default::DeprecationWarning
+         PYTHONWARNINGS=default::DeprecationWarningx
 passenv = TRAVIS
 deps = -r{toxinidir}/test-requirements.txt
-       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/yoga-m3#egg=neutron}
+       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/yoga-m3\#egg=neutron}
 whitelist_externals = sh
 commands = python setup.py testr --slowest --testr-args='{posargs}'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist = py27,py36
-minversion = 1.6
+envlist = py38
+minversion = 3.18.0
 skipsdist = True
 
 [testenv]
 usedevelop = True
-install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/ussuri-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
+install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
          PYTHONWARNINGS=default::DeprecationWarning
 passenv = TRAVIS
 deps = -r{toxinidir}/test-requirements.txt
-       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/ussuri-m3#egg=neutron}
+       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/yoga-m3#egg=neutron}
 whitelist_externals = sh
 commands = python setup.py testr --slowest --testr-args='{posargs}'
 


### PR DESCRIPTION
For ressource router_interface and event before_create the parameter (context, router_id, network_id) passed to the callback system changed to dbevent payload. [(Notify call)](https://github.com/sapcc/neutron/blob/f9070846ab151daf428167d0e521e3ba482b3355/neutron/db/l3_db.py#L817-L822)
