### PR TITLE
Advertise extraroute-atomic extension

### DIFF
--- a/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
@@ -36,6 +36,7 @@ LOG = logging.getLogger(__name__)
 class ASR1KRouterPlugin(l3_extension_adapter.ASR1KPluginBase, base.ServicePluginBase):
     supported_extension_aliases = ["router",
                                    "extraroute",
+                                   "extraroute-atomic",
                                    "l3_agent_scheduler",
                                    "router_availability_zone",
                                    "asr1k_operations"]


### PR DESCRIPTION
We support extraroute-atomic, but don't advertise it properly, which means it does not appear in the available OpenStack network extensions. This advertising is needed for clients which want to decide if they can use that API or not.

Reviewing the whole way we manage supported_extension_aliases shows that we should probably rework this code and orient ourselves a bit at what happened in the reference implementation in neutron, but today is not that day.