### PR TITLE
Silence error on ext gw without address scope

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -72,7 +72,7 @@ class Router(Base):
             if self.gateway_interface.address_scope in address_scope_config:
                 rt = address_scope_config[self.gateway_interface.address_scope]
                 global_vrf_id = self._to_global_vrf_id(rt)
-            else:
+            elif self.gateway_interface.address_scope is not None:
                 LOG.error("Router %s has a gateway interface, but no address scope was found in config"
                           "(address scope of router: %s, available scopes: %s",
                           self.router_id, self.gateway_interface.address_scope, list(address_scope_config.keys()))


### PR DESCRIPTION
The external gateway of a router normally has an address scope set and if that address scope cannot be found in our driver config we log an error message. This is the behavior we want for everything that has an address scope. For setups where the external gateway it not an external network and therefore also has no address scope is set we actually don't want this to be logged, as everything should be okay.

We'll silence the error for everything that has no address scope. This also means that we won't log the error for external networks that have been configured without any subnet with an address scope, but as this is more of an admin error and I don't want to fetch the external gateway only for deciding if we want to log this error I'll leave it this way for now.