### PR TITLE
Add option only to disable scheduling on an agent

### DIFF
--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -103,6 +103,8 @@ AGENT_STATE_OPTS = [
                         'is half or less than agent_down_time.')),
     cfg.BoolOpt('log_agent_heartbeats', default=False,
                 help=_('Log agent heartbeats')),
+    cfg.BoolOpt('scheduling_disabled', default=False,
+                help="No new routers will be scheduled on this L3 agent."),
 ]
 
 

--- a/asr1k_neutron_l3/plugins/l3/agents/asr1k_l3_agent.py
+++ b/asr1k_neutron_l3/plugins/l3/agents/asr1k_l3_agent.py
@@ -825,9 +825,12 @@ class L3ASRAgentWithStateReport(L3ASRAgent):
             'availability_zone': self.conf.AGENT.availability_zone,
             'topic': topics.L3_AGENT,
             'configurations': {
-                'log_agent_heartbeats': self.conf.AGENT.log_agent_heartbeats},
+                'log_agent_heartbeats': self.conf.AGENT.log_agent_heartbeats,
+                'scheduling_disabled': self.conf.AGENT.scheduling_disabled,
+            },
             'start_flag': True,
-            'agent_type': constants.AGENT_TYPE_ASR1K_L3}
+            'agent_type': constants.AGENT_TYPE_ASR1K_L3,
+        }
         report_interval = self.conf.AGENT.report_interval
 
         if report_interval:

--- a/asr1k_neutron_l3/plugins/l3/schedulers/simple_asr1k_scheduler.py
+++ b/asr1k_neutron_l3/plugins/l3/schedulers/simple_asr1k_scheduler.py
@@ -18,6 +18,8 @@ from neutron.scheduler import l3_agent_scheduler
 from oslo_config import cfg
 from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
+from oslo_serialization import jsonutils
+
 
 from asr1k_neutron_l3.common import asr1k_constants as asr1k_const
 
@@ -47,17 +49,29 @@ class SimpleASR1KScheduler(l3_agent_scheduler.AZLeastRoutersScheduler):
 
             orig_candidates = plugin.get_l3_agents(context, active=True)
 
+            enabled_candidates = []
+            disabled_hosts = []
+            for candidate in orig_candidates:
+                if not jsonutils.loads(candidate.configurations).get('scheduling_disabled', False):
+                    enabled_candidates.append(candidate)
+                else:
+                    disabled_hosts.append(candidate.host)
+
+            if disabled_hosts:
+                LOG.debug('Ignoring agent hosts %s scheduling disabled for scheduling of %s',
+                          ', '.join(disabled_hosts), sync_router["id"])
+
             # router creation with az hint: only schedule on agent with appropriate AZ
             # router creation without az hint: only schedule on agent with no AZ
             az_hints = orig_az_hints = self._get_az_hints(sync_router)
             if not az_hints or az_hints[0] in asr1k_const.NO_AZ_LIST:
                 az_hints = asr1k_const.NO_AZ_LIST
-            candidates = [c for c in orig_candidates if c.availability_zone in az_hints]
+            candidates = [c for c in enabled_candidates if c.availability_zone in az_hints]
 
             if not candidates and orig_az_hints and cfg.CONF.asr1k.ignore_invalid_az_hint_for_router:
                 LOG.warning("No candidate found for router %s with az hint %s, reverting to original candidate list %s",
-                            sync_router['id'], az_hints, orig_candidates)
-                candidates = orig_candidates
+                            sync_router['id'], az_hints, enabled_candidates)
+                candidates = enabled_candidates
 
             if not candidates:
                 LOG.warning('No active L3 agents found for router %s (az hints were %s)',


### PR DESCRIPTION
admin-shutting an agent leads to the agent being completely vacated. However we have cases in which we want an agent to stay online, but prevent any new workloads to be scheduled on it. This can be a capacity consideration or because it is meant to be decomissioned.