### PR TITLE
Delay route configuration after interface configuration

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -336,7 +336,6 @@ class Router(Base):
             results.append(self.pbr_acl.update())
         # Working assumption is that any NAT mode migration is completed
 
-        results.append(self.routes.update())
         results.append(self.floating_ips.update())
         results.append(self.arp_entries.update())
 
@@ -344,6 +343,8 @@ class Router(Base):
         for interface in self.interfaces.all_interfaces:
             if not isinstance(interface, l3_interface.OrphanedInterface):
                 results.append(interface.update())
+
+        results.append(self.routes.update())
 
         # We don't remove NAT statement or pool if enabling/disabling snat - instead update ACL
         if self.gateway_interface is not None:


### PR DESCRIPTION
When a router/VRF is part of a BGPVPN, the BGPVPN portion is configured
first. If a BGPVPN happens to have a peer on the local agent (hardware
router) this peer VRF's routes are leaked into the to be configured VRF.
Due to the order of operation, this leaking happens before any
VRF-attached l3 interfaces are configured.

Now say, a customer also configured an extra route. That extra route
also happens to be contained in a leaked route and that extra routes's
next hop also happens to be another BD-VIF in a BGPVPN-peered-VRF that
is local on that hardware router.

Even though the to be configured VRF has no l3 interface yet, it already
has a BGP RIB path pointing to that next hop address of the extra route.
It also believes it's a local interface, which it is, but it also is
not, because that BD-VIF lives in another VRF.

The hardware router not caring about such technicalities, will refuse to
configure the extra route with `%Invalid next hop address (it's this
router)` and all subsequent configuration fails.

The fact that the next hop lives on the same route can however be
obscured if the next hop is directly connected. It becomes directly
connected when the BD-VIFs are configure prior. So let's do that.

OpenStack also prevents you from creating extra routes where the next
hop is not local to the virtual router, so I think all cases should be
covered. Even on interface removal, OpenStack checks if a route still
utilizes that interface.

See https://github.com/sapcc/neutron/blob/5fb5653ffe700a8f9fb0949d16ecbf0978b61fb6/neutron/db/extraroute_db.py#L74-L86
https://github.com/sapcc/neutron/blob/5fb5653ffe700a8f9fb0949d16ecbf0978b61fb6/neutron/db/extraroute_db.py#L154-L164