### PR TITLE
Add floating ip ARP cleaning sync loop to agent

### DIFF
--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -87,6 +87,8 @@ ASR1K_L3_OPTS = [
                help="Set ARP timeout for the external interface of a router. Set to 0 to not set this attribute"),
     cfg.IntOpt('internal_iface_arp_timeout', default=0,
                help="Set ARP timeout for the external interface of a router. Disabled by default"),
+    cfg.BoolOpt('enable_arp_cleaning', default=True, help="Run ARP cleaning sync to remove stale macs of floating ips"),
+    cfg.IntOpt('arp_cleaning_interval', default=120, help="Interval for ARP cleaning"),
 ]
 
 ASR1K_L2_OPTS = [

--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -83,6 +83,10 @@ ASR1K_L3_OPTS = [
                help="Route-Map to apply to all DAPNet BGP network statements"),
     cfg.StrOpt('dapnet_extra_routes_rm', default='RM-DAP-EXTRA-ROUTES',
                help="Route-Map to apply to all BGP network statements for extra routes that are contained in a DAPNet"),
+    cfg.IntOpt('external_iface_arp_timeout', default=1800,
+               help="Set ARP timeout for the external interface of a router. Set to 0 to not set this attribute"),
+    cfg.IntOpt('internal_iface_arp_timeout', default=0,
+               help="Set ARP timeout for the external interface of a router. Disabled by default"),
 ]
 
 ASR1K_L2_OPTS = [

--- a/asr1k_neutron_l3/common/prometheus_monitor.py
+++ b/asr1k_neutron_l3/common/prometheus_monitor.py
@@ -39,6 +39,7 @@ DETAIL_LABELS = ['host', 'device', 'entity', 'action']
 BASIC_LABELS = ['host']
 STATS_LABELS = ['host', 'status']
 DEVICE_ENTITY_COUNT_LABELS = ['host', 'device', 'entity']
+FIP_ON_WRONG_MAC_COUNT_LABELS = ['host', 'device', 'vrf']
 
 L2 = "l2"
 L3 = "l3"
@@ -87,6 +88,9 @@ class PrometheusMonitor(object):
 
         self._device_entity_count = Gauge('device_entity_count', 'Number of instances of an entity present on device',
                                           DEVICE_ENTITY_COUNT_LABELS, namespace=self.namespace)
+        self._fip_on_wrong_mac_count = Counter('fip_on_wrong_mac_count',
+                                               'Number of times a FIP was found on the wrong mac',
+                                               FIP_ON_WRONG_MAC_COUNT_LABELS, namespace=self.namespace)
 
         if self.type == L3:
             self._router_create_duration = Histogram("router_create_duration", "Router create duration in seconds",

--- a/asr1k_neutron_l3/models/netconf_yang/arp_cache.py
+++ b/asr1k_neutron_l3/models/netconf_yang/arp_cache.py
@@ -1,0 +1,118 @@
+# Copyright 2023 SAP SE
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import re
+
+from oslo_log import log as logging
+
+from asr1k_neutron_l3.models.connection import ConnectionManager
+from asr1k_neutron_l3.models.netconf_yang.ny_base import NyBase, execute_on_pair
+from asr1k_neutron_l3.common.prometheus_monitor import PrometheusMonitor
+
+LOG = logging.getLogger(__name__)
+
+
+class ArpCacheConstants:
+    ARP_DATA = 'arp-data'
+    ARP_VRF = 'arp-vrf'
+    VRF = 'vrf'
+    ARP_ENTRY = 'arp-entry'
+
+
+class VRFArpEntry(NyBase):
+    @classmethod
+    def __parameters__(cls):
+        return [
+            {'key': 'address'},
+            {'key': 'mac', 'yang-key': 'hardware'},
+        ]
+
+    def to_dict(self, context):
+        return {'address': self.address, 'mac': self.mac}
+
+
+class VRFArpCache(NyBase):
+    @classmethod
+    def __parameters__(cls):
+        return [
+            {'key': 'vrf', 'yang-key': ArpCacheConstants.VRF, 'default': ''},
+            {'key': 'entries', 'yang-key': ArpCacheConstants.ARP_ENTRY, 'type': [VRFArpEntry], 'default': []},
+        ]
+
+    def to_dict(self, context):
+        return {'vrf': self.vrf, 'entries': [entry.to_dict(context) for entry in self.entries]}
+
+
+class ArpCache(NyBase):
+    ITEM_KEY = ArpCacheConstants.ARP_DATA
+
+    ID_FILTER = """
+      <arp-data xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-arp-oper">
+        <arp-vrf>
+          <vrf/>
+          <arp-entry>
+            <address/>
+            <hardware/>
+          </arp-entry>
+        </arp-vrf>
+      </arp-data>
+    """
+
+    CLEAN_ARP_ENTRY = """
+      <clear xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-rpc">
+        <arp-cache>
+          <vrf>{vrf}</vrf>
+          <ip-drop-node-name>{ip}</ip-drop-node-name>
+        </arp-cache>
+      </clear>
+    """
+
+    VRF_RE = re.compile("^[0-9a-f]{32}$")
+
+    @classmethod
+    def __parameters__(cls):
+        return [
+            {'key': 'vrfs', 'yang-key': ArpCacheConstants.ARP_VRF, 'type': [VRFArpCache], 'default': []},
+        ]
+
+    @classmethod
+    @execute_on_pair()
+    def clean_device_arp(cls, context, fip_data):
+        LOG.debug("Host %s: Fetching ARP data", context.host)
+
+        stale_entries = []
+        arp_data = cls._get(context=context)
+        for vrf in arp_data.vrfs:
+            if not cls.VRF_RE.match(vrf.vrf):
+                continue
+
+            for entry in vrf.entries:
+                if fip_data.get(entry.address) not in (None, entry.mac):
+                    stale_entries.append((vrf.vrf, entry.address, entry.mac, fip_data[entry.address]))
+                    PrometheusMonitor().fip_on_wrong_mac_count.label(device=context.host, vrf=vrf.vrf).inc()
+        LOG.debug("ARP cleanup on host %s for %s fips and %s ARP entries with %s stale entries",
+                  context.host, len(fip_data), sum(len(vrf.entries) for vrf in arp_data.vrfs), len(stale_entries))
+
+        if stale_entries:
+            with ConnectionManager(context=context) as connection:
+                for vrf, ip, wrong_mac, mac in stale_entries:
+                    LOG.warning("Host %s VRF %s has stale entry for ip %s on mac %s, should be %s - cleaning it",
+                                context.host, vrf, ip, wrong_mac, mac)
+                    connection.rpc(cls.CLEAN_ARP_ENTRY.format(vrf=vrf, ip=ip),
+                                   entity=cls.__name__, action="clean_arp")
+
+    def to_dict(self, context):
+        return {'vrfs': [vrf.to_dict(context) for vrf in self.vrfs]}

--- a/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
@@ -59,6 +59,8 @@ class L3Constants(object):
     DIRECTION_OUT = "out"
     NTP = "ntp"
     NTP_DISABLE = "disable"
+    ARP = "arp"
+    TIMEOUT = "timeout"
 
 
 class VBInterface(NyBase):
@@ -144,7 +146,8 @@ class VBInterface(NyBase):
             {'key': 'redundancy_group'},
             {'key': 'shutdown', 'default': False, 'yang-type': YANG_TYPE.EMPTY},
             {'key': 'ntp_disable', 'yang-key': 'disable', 'yang-path': 'ntp', 'default': False,
-             'yang-type': YANG_TYPE.EMPTY}
+             'yang-type': YANG_TYPE.EMPTY},
+            {'key': 'arp_timeout', 'yang-key': 'timeout', 'yang-path': 'arp'},
         ]
 
     def __init__(self, **kwargs):
@@ -226,6 +229,11 @@ class VBInterface(NyBase):
                 vbi[L3Constants.NTP][L3Constants.NTP_DISABLE] = ''
             else:
                 vbi[L3Constants.NTP][xml_utils.OPERATION] = NC_OPERATION.REMOVE
+
+        if self.arp_timeout and int(self.arp_timeout) > 0:
+            vbi[L3Constants.ARP] = {L3Constants.TIMEOUT: int(self.arp_timeout)}
+        else:
+            vbi[L3Constants.ARP] = {L3Constants.TIMEOUT: {xml_utils.OPERATION: NC_OPERATION.DELETE}}
 
         result = OrderedDict()
         result[context.bd_iftype] = vbi

--- a/asr1k_neutron_l3/models/netconf_yang/xml_utils.py
+++ b/asr1k_neutron_l3/models/netconf_yang/xml_utils.py
@@ -35,6 +35,7 @@ NS_CISCO_EFP_OPER = 'http://cisco.com/ns/yang/Cisco-IOS-XE-efp-oper'
 NS_CISCO_ARP = 'http://cisco.com/ns/yang/Cisco-IOS-XE-arp'
 NS_CISCO_BRIDGE_DOMAIN = 'http://cisco.com/ns/yang/Cisco-IOS-XE-bridge-domain'
 NS_CISCO_NTP = 'http://cisco.com/ns/yang/Cisco-IOS-XE-ntp'
+NS_CISCO_ARP_OPER = 'http://cisco.com/ns/yang/Cisco-IOS-XE-arp-oper'
 NS_IETF_INTERFACE = "urn:ietf:params:xml:ns:yang:ietf-interfaces"
 
 
@@ -66,6 +67,7 @@ class XMLUtils(object):
         NS_IETF_INTERFACE: None,
         NS_CISCO_BRIDGE_DOMAIN: None,
         NS_CISCO_NTP: None,
+        NS_CISCO_ARP_OPER: None,
     }
 
     @classmethod

--- a/asr1k_neutron_l3/models/neutron/l3/interface.py
+++ b/asr1k_neutron_l3/models/neutron/l3/interface.py
@@ -13,6 +13,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from oslo_config import cfg
 from oslo_log import log as logging
 
 from asr1k_neutron_l3.common import utils
@@ -135,7 +136,7 @@ class GatewayInterface(Interface):
                                             ip_address=self.ip_address,
                                             secondary_ip_addresses=self.secondary_ip_addresses, nat_outside=True,
                                             redundancy_group=None, route_map='EXT-TOS', access_group_out='EXT-TOS',
-                                            ntp_disable=True)
+                                            ntp_disable=True, arp_timeout=cfg.CONF.asr1k_l3.external_iface_arp_timeout)
 
     def _nat_address(self):
         ips = self.router_port.get('fixed_ips')
@@ -160,7 +161,7 @@ class InternalInterface(Interface):
                                             ip_address=self.ip_address,
                                             secondary_ip_addresses=self.secondary_ip_addresses,
                                             nat_inside=True, redundancy_group=None, route_map="pbr-{}".format(self.vrf),
-                                            ntp_disable=True)
+                                            ntp_disable=True, arp_timeout=cfg.CONF.asr1k_l3.internal_iface_arp_timeout)
 
 
 class OrphanedInterface(Interface):

--- a/asr1k_neutron_l3/plugins/l3/rpc/rpc_api.py
+++ b/asr1k_neutron_l3/plugins/l3/rpc/rpc_api.py
@@ -121,3 +121,7 @@ class ASR1KRpcAPI(l3_rpc.L3RpcCallback):
     def get_usage_stats(self, context, **kwargs):
         host = kwargs.get('host')
         return self.db.get_usage_stats(context, host)
+
+    @instrument()
+    def get_floating_ips_with_router_macs(self, context, fips=None, router_id=None):
+        return self.db.get_floating_ips_with_router_macs(context, fips=fips, router_id=router_id)


### PR DESCRIPTION
The agent now as an ARP cleaning syncloop. By default every two minutes (though it is configurable). The agent fetches all fip --> router mac associations. We expect each fip - if we see it - to be on the mac address of the gateway interface of our router. Then, for each device on the agent, we fetch the ARP cache and look for IPs that we know about and are on the wrong mac. Everything wrong will then be cleared.

Fetching all ARP entries from a device takes about 1.2-4.0s in my tests, depending on the ARP table size on the device. Selecting only a subset of fields makes the query go something like 20-40% faster.

---

Some things are still left open for discussion:
 * Our fips are not VRF or address scope aware, do we need to match fip address scope to the VRFs address scopes to check if we can clear it? FIPs might be unique, but needs checking (don't remember of the top of my mind).
 * Is fetching the ARP table possible everywhere where we need it (should run through the regions and do a short check)
 * Do we need to add an API point to run ARP cleaning via it? Probably not with 2 minutes, but with a longer interval it might be interesting.
 * Currently we do "whole region" arp cleaning, cause it is quite fast, but if it's not.... Would it make sense to bump the syncloop up to ~15 minutes and do a check where we see when a FIP was used the last time and specifically clear it everywhere?
     * fetching the ARP table could be filtered by IP (I think)
     * extra bookkeeping needed, as we would need to remember when a FIP was last used. Might be doable via standard attributes, might not be.