### PR TITLE
Use remove instead of delete for unsetting ARP timeout

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
@@ -233,7 +233,7 @@ class VBInterface(NyBase):
         if self.arp_timeout and int(self.arp_timeout) > 0:
             vbi[L3Constants.ARP] = {L3Constants.TIMEOUT: int(self.arp_timeout)}
         else:
-            vbi[L3Constants.ARP] = {L3Constants.TIMEOUT: {xml_utils.OPERATION: NC_OPERATION.DELETE}}
+            vbi[L3Constants.ARP] = {L3Constants.TIMEOUT: {xml_utils.OPERATION: NC_OPERATION.REMOVE}}
 
         result = OrderedDict()
         result[context.bd_iftype] = vbi


### PR DESCRIPTION
The delete action will error out if the attribute that we wanted to delete does not exist. Remove will just silently ignore it, which is exactly what we want.