### PR TITLE
Use remove instead of delete for bridge members

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/l2_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l2_interface.py
@@ -210,7 +210,7 @@ class BDIfMember(NyBase):
             result[L2Constants.BD_SERVICE_INSTANCE_LIST] = service_instances
 
         if self.mark_deleted:
-            result[xml_utils.OPERATION] = NC_OPERATION.DELETE
+            result[xml_utils.OPERATION] = NC_OPERATION.REMOVE
         return result
 
 
@@ -243,7 +243,7 @@ class BDVIFMember(NyBase):
             L2Constants.NAME: self.name,
         }
         if self.mark_deleted:
-            result[xml_utils.OPERATION] = NC_OPERATION.DELETE
+            result[xml_utils.OPERATION] = NC_OPERATION.REMOVE
 
         return result
 


### PR DESCRIPTION
In some cases we want to delete a bridge member, maybe even as a "side operation", i.e. triggered by another operation. If the interface has already been removed (by the cleaning loop, another thread or whatever) we don't want to fail, but silently ignore this. Therefore "remove" seems to be the operation which is more fitting.

One could argue that this is the operation we want to use in most cases in this driver... well, we're getting there.