### PR TITLE
Don't get subnet CIDR if not present

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/interface.py
+++ b/asr1k_neutron_l3/models/neutron/l3/interface.py
@@ -90,6 +90,7 @@ class Interface(base.Base):
         for subnet in self.router_port.get('subnets', []):
             if subnet.get('id') == self._primary_subnet_id:
                 return subnet
+        return None
 
     @property
     def subnets(self):

--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -193,7 +193,7 @@ class Router(Base):
         if self.gateway_interface:
             subnet = self.gateway_interface.primary_subnet
 
-            if subnet.get('cidr') is not None:
+            if subnet is not None and subnet.get('cidr') is not None:
                 ip, netmask = utils.from_cidr(subnet.get('cidr'))
                 wildcard = utils.to_wildcard_mask(netmask)
                 rule = access_list.Rule(destination=ip, destination_mask=wildcard)


### PR DESCRIPTION
When instantiating our Router when the router has no subnet (or we somehow didn't find one, the router was not deleted... I am not quite sure on the properties triggering this) this might result in an AttributeError, where in _build_pbr_acl() the
self.gateway_interface.primary_subnet is None and therefore has no member .get(). To fix this we simply check if the given subnet is None beforehand.