### PR TITLE
Fix CapabilityNotFoundException argument name

### DIFF
--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -358,4 +358,4 @@ class YangConnection(object):
 
                 return schema_rev_date >= min_rev_date
 
-        raise CapabilityNotFoundException(host=self.context.host, entity_name=baseurl)
+        raise CapabilityNotFoundException(host=self.context.host, entity=baseurl)


### PR DESCRIPTION
The argument for the failing entity is called entity, not entity_name.