### PR TITLE
Fallback to native/version for capability check

### DIFF
--- a/asr1k_neutron_l3/models/asr1k_pair.py
+++ b/asr1k_neutron_l3/models/asr1k_pair.py
@@ -18,7 +18,8 @@ from oslo_log import log as logging
 from oslo_config import cfg
 
 from asr1k_neutron_l3.common import config as asr1k_config
-from asr1k_neutron_l3.common.asr1k_exceptions import VersionInfoNotAvailable
+from asr1k_neutron_l3.common.asr1k_exceptions import CapabilityNotFoundException, VersionInfoNotAvailable
+from asr1k_neutron_l3.models.netconf_yang import xml_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -82,14 +83,37 @@ class ASR1KContext(ASR1KContextBase):
         from asr1k_neutron_l3.models.connection import ConnectionManager
 
         with ConnectionManager(context=self) as connection:
-            # ASR 17.3 has at least this version for the YANG native model
-            self._version_min_17_3 = connection.check_capability(module="Cisco-IOS-XE-native",
-                                                                 min_revision="2020-07-01")
-            # IOS XE 17.6 has at least this version for the YANG native model
-            self._version_min_17_6 = connection.check_capability(module="Cisco-IOS-XE-native",
-                                                                 min_revision="2021-07-20")
-            self._has_stateless_nat = connection.check_capability(module="Cisco-IOS-XE-nat",
-                                                                  min_revision="2020-11-01")
+            try:
+                # ASR 17.3 has at least this version for the YANG native model
+                self._version_min_17_3 = connection.check_capability(module="Cisco-IOS-XE-native",
+                                                                     min_revision="2020-07-01")
+                # IOS XE 17.6 has at least this version for the YANG native model
+                self._version_min_17_6 = connection.check_capability(module="Cisco-IOS-XE-native",
+                                                                     min_revision="2021-07-20")
+                self._has_stateless_nat = connection.check_capability(module="Cisco-IOS-XE-nat",
+                                                                      min_revision="2020-11-01")
+            except CapabilityNotFoundException:
+                # newer images don't advertise all their capabilities, so we need to check the version
+                ver_xml_data = connection.xpath_get("native/version")
+                ver_data = xml_utils.XMLUtils.to_raw_json(ver_xml_data.xml)
+                try:
+                    ver = ver_data['rpc-reply']['data']['native']['version'].split(".")
+                except KeyError as e:
+                    LOG.error("Tried to fetch version for host %s, but couldn't parse the response: %s", self.host, e)
+                    raise CapabilityNotFoundException(host=self.host, entity="native/version")
+
+                # "parse" version
+                def _to_int_if_possible(d):
+                    try:
+                        return int(d)
+                    except ValueError:
+                        return d
+
+                ver = tuple(_to_int_if_possible(d) for d in ver)
+
+                self._version_min_17_3 = ver >= (17, 3)
+                self._version_min_17_6 = ver >= (17, 6)
+                self._has_stateless_nat = ver >= (17, 4)
 
         self._got_version_info = True
 


### PR DESCRIPTION
Newer versions of the Cisco router firmware do not advertise their Cisco-IOS_XE-native version anymore, so we have to fallback onto another way of determining the firmware version. Asking for native/version returns the current firmware version (17.3, 17.4, ...), which we can currently use for all present feature switches. If this works out properly we could also use it as the main way to determine the feature set of a device, even let our YANG Models match themselves on versions.