### PR TITLE
Set GARP flag for FIPs on 17.13

### DIFF
--- a/asr1k_neutron_l3/models/asr1k_pair.py
+++ b/asr1k_neutron_l3/models/asr1k_pair.py
@@ -42,9 +42,10 @@ class FakeASR1KContext(ASR1KContextBase):
     stable results
     """
 
-    def __init__(self, version_min_17_3=True, version_min_17_6=True, has_stateless_nat=True):
+    def __init__(self, version_min_17_3=True, version_min_17_6=True, version_min_17_13=True, has_stateless_nat=True):
         self.version_min_17_3 = version_min_17_3
         self.version_min_17_6 = version_min_17_6
+        self.version_min_17_13 = version_min_17_13
         self._has_stateless_nat = has_stateless_nat
 
     @property
@@ -55,6 +56,7 @@ class FakeASR1KContext(ASR1KContextBase):
 class ASR1KContext(ASR1KContextBase):
     version_min_17_3 = property(lambda self: self._get_version_attr('_version_min_17_3'))
     version_min_17_6 = property(lambda self: self._get_version_attr('_version_min_17_6'))
+    version_min_17_13 = property(lambda self: self._get_version_attr('_version_min_17_13'))
     has_stateless_nat = property(lambda self: self._get_version_attr('_has_stateless_nat'))
 
     def __init__(self, name, host, yang_port, nc_timeout, username, password, use_bdvif, insecure=True,
@@ -103,6 +105,7 @@ class ASR1KContext(ASR1KContextBase):
 
             self._version_min_17_3 = ver >= (17, 3)
             self._version_min_17_6 = ver >= (17, 6)
+            self._version_min_17_13 = ver >= (17, 13)
             self._has_stateless_nat = ver >= (17, 4)
 
         self._got_version_info = True

--- a/asr1k_neutron_l3/models/netconf_yang/nat.py
+++ b/asr1k_neutron_l3/models/netconf_yang/nat.py
@@ -34,6 +34,7 @@ class NATConstants(object):
     INTERFACE = "interface"
     INTERFACE_WITH_VRF = 'interface-with-vrf'
     BDI = "BDI"
+    BDVIF = "BD-VIF"
     ID = "id"
     START_ADDRESS = "start-address"
     END_ADDRESS = "end-address"
@@ -56,6 +57,7 @@ class NATConstants(object):
     MATCH_IN_VRF = "match-in-vrf"
     STATELESS = "stateless"
     NO_ALIAS = "no-alias"
+    GARP_IFACE = 'garp-interface'
 
 
 class NatPool(NyBase):
@@ -601,6 +603,7 @@ class StaticNat(NyBase):
             {'key': 'match_in_vrf', 'yang-type': YANG_TYPE.EMPTY, 'default': False},
             {'key': 'stateless', 'yang-type': YANG_TYPE.EMPTY, 'default': False},
             {'key': 'no_alias', 'yang-type': YANG_TYPE.EMPTY, 'default': False},
+            {'key': 'garp_bdvif_iface', 'yang-path': 'garp-interface/BD-VIF'},
         ]
 
     @classmethod
@@ -691,6 +694,11 @@ class StaticNat(NyBase):
                 entry[NATConstants.MAPPING_ID] = self.mapping_id
             if context.version_min_17_6:
                 entry[NATConstants.NO_ALIAS] = ""
+            if context.version_min_17_13:
+                if self.garp_bdvif_iface:
+                    entry[NATConstants.GARP_IFACE] = {NATConstants.BDVIF: str(self.garp_bdvif_iface)}
+                else:
+                    entry[NATConstants.GARP_IFACE] = {xml_utils.OPERATION: NC_OPERATION.REMOVE}
         else:
             if self.stateless:
                 entry[NATConstants.STATELESS] = ""

--- a/asr1k_neutron_l3/models/neutron/l3/nat.py
+++ b/asr1k_neutron_l3/models/neutron/l3/nat.py
@@ -154,13 +154,16 @@ class FloatingIp(BaseNAT):
         self.id = "{},{}".format(self.local_ip, self.global_ip)
         self.mapping_id = utils.uuid_to_mapping_id(self.floating_ip.get('id'))
         self.mac_address = None
+        self.garp_iface_id = None
         if self.gateway_interface:
             self.mac_address = self.gateway_interface.mac_address
+            self.garp_iface_id = self.gateway_interface.bridge_domain
         self._rest_definition = l3_nat.StaticNat(vrf=self.router_id, local_ip=self.local_ip, global_ip=self.global_ip,
                                                  mask=self.global_ip_mask, bridge_domain=self.bridge_domain,
                                                  redundancy=self.redundancy, mapping_id=self.mapping_id,
                                                  mac_address=self.mac_address, match_in_vrf=True,
-                                                 stateless=cfg.CONF.asr1k_l3.stateless_nat)
+                                                 stateless=cfg.CONF.asr1k_l3.stateless_nat,
+                                                 garp_bdvif_iface=self.garp_iface_id)
 
     def get(self):
         static_nat = l3_nat.StaticNat.get(self.local_ip, self.global_ip)

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_parsing.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_parsing.py
@@ -373,3 +373,38 @@ class ParsingTest(base.BaseTestCase):
         self.assertEqual("2742f0347af546878c600d608cf38382", vrf1.vrf)
         self.assertEqual("1.2.3.4", vrf1.entries[0].address)
         self.assertEqual("fa:16:3e:11:22:33", vrf1.entries[0].mac)
+
+    def test_parse_nat_garp_flag(self):
+        xml = """
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"
+    message-id="urn:uuid:9caf3918-3eb9-4d0e-a8a5-5ec268e3bf97">
+    <data>
+      <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+        <ip>
+          <nat xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-nat">
+            <inside>
+              <source>
+                <static>
+                  <nat-static-transport-list-with-vrf>
+                    <local-ip>10.180.250.161</local-ip>
+                    <global-ip>10.216.24.4</global-ip>
+                    <vrf>76433b4941974003a881847fda8af23b</vrf>
+                    <no-alias/>
+                    <match-in-vrf/>
+                    <stateless/>
+                    <garp-interface>
+                      <BD-VIF>6657</BD-VIF>
+                    </garp-interface>
+                  </nat-static-transport-list-with-vrf>
+                </static>
+              </source>
+            </inside>
+          </nat>
+        </ip>
+      </native>
+  </data>
+</rpc-reply>"""
+        context = FakeASR1KContext()
+        snl = StaticNatList.from_xml(xml, context)
+        nat = snl.static_nats[0]
+        self.assertEqual('6657', nat.garp_bdvif_iface)


### PR DESCRIPTION
Firmware 17.13 starts to support the garp-interface option for static NAT configuration. This means that on configuration a gratuitous ARP will be send out on configuration of the statement. To use this, we need to be at least on 17.13. The target interface will always be the gateway interface. Without a gateway interface, the flag will be removed.