### PR TITLE
Fix missing space and bracket in error message

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -73,8 +73,8 @@ class Router(Base):
                 rt = address_scope_config[self.gateway_interface.address_scope]
                 global_vrf_id = self._to_global_vrf_id(rt)
             elif self.gateway_interface.address_scope is not None:
-                LOG.error("Router %s has a gateway interface, but no address scope was found in config"
-                          "(address scope of router: %s, available scopes: %s",
+                LOG.error("Router %s has a gateway interface, but no address scope was found in config "
+                          "(address scope of router: %s, available scopes: %s)",
                           self.router_id, self.gateway_interface.address_scope, list(address_scope_config.keys()))
 
         if not self.router_atts.get('rd'):


### PR DESCRIPTION
The "missing address scope for router" message was missing a space and a closing bracket at the end.