### PR TITLE
Enable native pagination/sorting/filtering

### DIFF
--- a/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/asr1k_router_plugin.py
@@ -41,6 +41,10 @@ class ASR1KRouterPlugin(l3_extension_adapter.ASR1KPluginBase, base.ServicePlugin
                                    "router_availability_zone",
                                    "asr1k_operations"]
 
+    __native_pagination_support = True
+    __native_sorting_support = True
+    __filter_validation_support = True
+
     def __init__(self):
         super(ASR1KRouterPlugin, self).__init__()
 


### PR DESCRIPTION
When these three attributes are not set, some part of the filtering and sorting is done in software in python instead directly via SQL. Upstream Neutron had these setting for some time and as we're using all the upstream methods to interact with routers (but do not inherit the L3Plugin baseclass, as we have our own there) we can set these attributes as well. It is questionable if this will make a big performance impact, as routers are not often paginated, but it probably won't hurt either.