### PR TITLE
Register Neutron cache options

### DIFF
--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -16,6 +16,7 @@
 
 from oslo_log import log as logging
 from oslo_config import cfg
+from neutron.common import cache_utils
 from neutron.conf.agent import common
 from neutron.conf import service
 from neutron_lib._i18n import _
@@ -153,6 +154,7 @@ def register_common_opts():
     cfg.CONF.register_opts(ASR1K_OPTS, "asr1k")
     cfg.CONF.register_opts(AGENT_STATE_OPTS, 'AGENT')
     common.register_availability_zone_opts_helper(cfg.CONF)
+    cache_utils.register_oslo_configs(cfg.CONF)
 
 
 def register_l3_opts():


### PR DESCRIPTION
We currently seem to rely on someone else registering the cache options. In the rare cases that nobody else registers these options we run into a NoSuchOptError exception. So, to make sure we have the opts and can use the cache we now register this ourselves. As I am not sure if we only need this in the l3 part vs if we need it in the ml2 part either now or later I decided to just register the ops for everyone in register_common_opts(). This problem only appears in the agent code so far.