### PR TITLE
Implement public-key authentication for netconf over ssh

### DIFF
--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -29,6 +29,7 @@ DEVICE_OPTS = [
     cfg.IntOpt('nc_timeout', default=5, help='Netconf-YANG timeout, default 5s'),
     cfg.StrOpt('user_name', default='admin', help='Netconf-YANG User'),
     cfg.StrOpt('password', default='secret', help='Netconf-YANG Password'),
+    cfg.ListOpt('ssh_keys', default=[], help='List of paths to ssh keys for authentication'),
     cfg.BoolOpt('use_bdvif', default=True, help='Use BD-VIF when supported by device firmware'),
 ]
 

--- a/asr1k_neutron_l3/common/prometheus_monitor.py
+++ b/asr1k_neutron_l3/common/prometheus_monitor.py
@@ -73,6 +73,8 @@ class PrometheusMonitor(object):
                                       DETAIL_LABELS, namespace=self.namespace)
         self._device_unreachable = Counter('device_unreachable', 'Unreachable device',
                                            DETAIL_LABELS, namespace=self.namespace)
+        self.ssh_key_successful_auth = Counter('ssh_key_successful_auth', 'Counter of successful SSH key usage',
+                                    [*BASIC_LABELS, 'md5_fingerprint'], namespace=self.namespace) 
         self._rpc_sync_errors = Counter('rpc_sync_errors', 'Sync block on RPC request',
                                         DETAIL_LABELS, namespace=self.namespace)
         self._connection_pool_exhausted = Counter('connection_pool_exhausted', 'Connnection pool  exhausted',

--- a/asr1k_neutron_l3/models/connection.py
+++ b/asr1k_neutron_l3/models/connection.py
@@ -32,7 +32,6 @@ from asr1k_neutron_l3.common.asr1k_exceptions import DeviceUnreachable, Capabili
 from asr1k_neutron_l3.common import asr1k_constants
 from asr1k_neutron_l3.common.prometheus_monitor import PrometheusMonitor
 
-from ncclient import manager
 from ncclient.xml_ import to_ele, new_ele, to_xml
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -243,7 +242,7 @@ class YangConnection(object):
                 except TransportError:
                     pass
                 finally:
-                    self._ncc_connection = self._connect(self.context)
+                    self._ncc_connection = self.context.get_nnc_connection()
         except Exception as e:
             if isinstance(e, TimeoutExpiredError) or isinstance(e, SSHError) or isinstance(e, SessionCloseError):
                 LOG.warning(
@@ -254,16 +253,6 @@ class YangConnection(object):
                 LOG.exception(e)
 
         return self._ncc_connection
-
-    def _connect(self, context):
-        port = context.yang_port
-
-        return manager.connect(
-            host=context.host, port=port,
-            username=context.username, password=context.password,
-            hostkey_verify=False,
-            device_params={'name': "iosxe"}, timeout=context.nc_timeout,
-            allow_agent=False, look_for_keys=False)
 
     def close(self):
         if self._ncc_connection is not None:


### PR DESCRIPTION
Rotating credentials can be easier using key authentication for two
reasons.
1. We read the key from disk on each authentication, allowing us to
   exchange the secret without having to restart the driver.
2. The device allows us to populate multiple keys for the same user.

With credential rotation in mind, we implement the ability to use
multiple keys and also report if authentication with those keys have
been successful, allowing third party tooling to verify that it is safe
to rotate a key.

The `_connect` has also been moved from the `YangConnection` class to
the `ASR1KContext` class. This has been done, as it was only using
attributes of `ASR1KContext`, it was using none of the YangConnection
attributes and could have been static. I also feel that is tightly
coupled with the `ASR1KContext`.
