### PR TITLE
Use route-maps instead of network for BGP prefixes

### DIFF
--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -83,6 +83,9 @@ ASR1K_L3_OPTS = [
                help="Route-Map to apply to all DAPNet BGP network statements"),
     cfg.StrOpt('dapnet_extra_routes_rm', default='RM-DAP-EXTRA-ROUTES',
                help="Route-Map to apply to all BGP network statements for extra routes that are contained in a DAPNet"),
+    # FIXME: move defaults away from here
+    cfg.ListOpt('dapn_extra_routes_communities', default=["65126", "4268097541"],
+                help="Communities to assign to DAPNet extraroutes (via redistribute statement)"),
     cfg.IntOpt('external_iface_arp_timeout', default=1800,
                help="Set ARP timeout for the external interface of a router. Set to 0 to not set this attribute"),
     cfg.IntOpt('internal_iface_arp_timeout', default=0,

--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -84,6 +84,8 @@ ASR1K_L3_OPTS = [
     cfg.StrOpt('dapnet_extra_routes_rm', default='RM-DAP-EXTRA-ROUTES',
                help="Route-Map to apply to all BGP network statements for extra routes that are contained in a DAPNet"),
     # FIXME: move defaults away from here
+    cfg.ListOpt('dapn_routable_nets_communities', default=["65126"],
+                help="Communities to assign to DAPNets (via redistribute statement)"),
     cfg.ListOpt('dapn_extra_routes_communities', default=["65126", "4268097541"],
                 help="Communities to assign to DAPNet extraroutes (via redistribute statement)"),
     cfg.IntOpt('external_iface_arp_timeout', default=1800,

--- a/asr1k_neutron_l3/models/netconf_yang/prefix.py
+++ b/asr1k_neutron_l3/models/netconf_yang/prefix.py
@@ -92,12 +92,10 @@ class Prefix(NyBase):
 
     @property
     def neutron_router_id(self):
-        if self.name is not None and self.name.startswith('ext-'):
-            return utils.vrf_id_to_uuid(self.name[4:])
-        elif self.name is not None and self.name.startswith('snat-'):
-            return utils.vrf_id_to_uuid(self.name[5:])
-        elif self.name is not None and self.name.startswith('route-'):
-            return utils.vrf_id_to_uuid(self.name[6:])
+        for prefix in 'ext-', 'snat-', 'route-', 'BGPVPN-', 'ROUTABLEINT-', 'ROUTABLEEXTRA-':
+            if self.name and self.name.startswith(prefix):
+                return utils.vrf_id_to_uuid(self.name[len(prefix):])
+        return None
 
     def add_seq(self, seq):
         if seq.no is None:

--- a/asr1k_neutron_l3/models/neutron/l3/bgp.py
+++ b/asr1k_neutron_l3/models/neutron/l3/bgp.py
@@ -23,7 +23,8 @@ from asr1k_neutron_l3.models.neutron.l3 import base
 
 class AddressFamily(base.Base):
     def __init__(self, vrf, asn=None, routable_interface=False, rt_export=[],
-                 connected_cidrs=[], routable_networks=[], extra_routes=[]):
+                 connected_cidrs=[], routable_networks=[], extra_routes=[],
+                 redist_rm=None):
         super(AddressFamily, self).__init__()
         self.vrf = utils.uuid_to_vrf_id(vrf)
         self.routable_interface = routable_interface
@@ -50,7 +51,8 @@ class AddressFamily(base.Base):
             self.enable_bgp = True
 
         self._rest_definition = bgp.AddressFamily(vrf=self.vrf, asn=self.asn, enable_bgp=self.enable_bgp,
-                                                  static=True, connected=True, networks_v4=self.networks_v4)
+                                                  networks_v4=self.networks_v4,
+                                                  static_with_rm=redist_rm, connected_with_rm=redist_rm)
 
     def get(self):
         return bgp.AddressFamily.get(self.vrf, asn=self.asn, enable_bgp=self.enable_bgp)

--- a/asr1k_neutron_l3/models/neutron/l3/route_map.py
+++ b/asr1k_neutron_l3/models/neutron/l3/route_map.py
@@ -94,12 +94,10 @@ class BgpvpnRedistRouteMap(base.Base):
         self.name = "BGPVPNREDIST-{}".format(self.vrf)
 
         sequences = [
-            # FIXME: remove once we decided we don't need it (as we do it via network statements)
             route_map.MapSequence(seq_no=10,
                                   operation='permit',
+                                  community_list=cfg.CONF.asr1k_l3.dapn_routable_nets_communities,
                                   access_list=f"{prefix.RoutableInternalPrefixes.PREFIX_NAME}-{self.vrf}"),
-
-            # FIXME: set community
             route_map.MapSequence(seq_no=20,
                                   operation='permit',
                                   community_list=cfg.CONF.asr1k_l3.dapn_extra_routes_communities,

--- a/asr1k_neutron_l3/models/neutron/l3/route_map.py
+++ b/asr1k_neutron_l3/models/neutron/l3/route_map.py
@@ -13,9 +13,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from oslo_config import cfg
+
 from asr1k_neutron_l3.common import utils
 from asr1k_neutron_l3.models.netconf_yang import route_map
-from asr1k_neutron_l3.models.neutron.l3 import base
+from asr1k_neutron_l3.models.neutron.l3 import base, prefix
 
 
 class RouteMap(base.Base):
@@ -80,5 +82,31 @@ class PBRRouteMap(base.Base):
             sequences.append(route_map.MapSequence(seq_no=15,
                                                    operation='permit',
                                                    ip_precedence='routine'))
+
+        self._rest_definition = route_map.RouteMap(name=self.name, seq=sequences)
+
+
+class BgpvpnRedistRouteMap(base.Base):
+    def __init__(self, router_id):
+        super().__init__()
+
+        self.vrf = utils.uuid_to_vrf_id(router_id)
+        self.name = "BGPVPNREDIST-{}".format(self.vrf)
+
+        sequences = [
+            # FIXME: remove once we decided we don't need it (as we do it via network statements)
+            route_map.MapSequence(seq_no=10,
+                                  operation='permit',
+                                  access_list=f"{prefix.RoutableInternalPrefixes.PREFIX_NAME}-{self.vrf}"),
+
+            # FIXME: set community
+            route_map.MapSequence(seq_no=20,
+                                  operation='permit',
+                                  community_list=cfg.CONF.asr1k_l3.dapn_extra_routes_communities,
+                                  access_list=f"{prefix.RoutableExtraPrefixes.PREFIX_NAME}-{self.vrf}"),
+            route_map.MapSequence(seq_no=30,
+                                  operation='permit',
+                                  access_list=f"{prefix.BgpvpnPrefixes.PREFIX_NAME}-{self.vrf}"),
+        ]
 
         self._rest_definition = route_map.RouteMap(name=self.name, seq=sequences)


### PR DESCRIPTION
The current firmware of our Cisco routers (<= 17.6) requires a full sync every time we touch the bgp subtree via netconf-yang. For our current prod regions can cause a complete config lock of the /native tree, which can take up to two minutes. In this timeframe no other reconfiguration is possible.

Before this commit we used network statements for advertising BGPVPNs and DAPNets. This is now done via "redistribute connected" and "redistribute static" + a route-map, to set the right communities for extraroutes overlapping with a DAPNet. The config will still get locked for DAPNet routers or when a BGPVPN is attached, but all subsequent modifications (like adding/deleting a subnet or adding/deleting an extraroute to the router) will only change a prefixlist and therefore not touch the BGP config tree.

Long term it would be desirable if Cisco would fix their confd implementation, though.

WIP:
 * config is still hardcoded, shouldn't be that way
 * we have to discuss if we want to advertise DAPNets via route-map or network statement