### PR TITLE
Register DEFAULT group on agent start

### DIFF
--- a/asr1k_neutron_l3/plugins/l3/agents/asr1k_l3_agent.py
+++ b/asr1k_neutron_l3/plugins/l3/agents/asr1k_l3_agent.py
@@ -88,6 +88,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 def main(manager='asr1k_neutron_l3.plugins.l3.agents.asr1k_l3_agent.L3ASRAgentWithStateReport'):
     asr1k_config.register_common_opts()
     asr1k_config.register_l3_opts()
+    common_config.register_common_config_options()
     common_config.init(sys.argv[1:])
     common_config.setup_logging()
     # set periodic interval to 10 seconds, as I understand the code this means

--- a/asr1k_neutron_l3/plugins/ml2/agents/asr1k_ml2_agent.py
+++ b/asr1k_neutron_l3/plugins/ml2/agents/asr1k_ml2_agent.py
@@ -65,6 +65,7 @@ SYNC_ROUTERS_MIN_CHUNK_SIZE = 32
 
 
 def main():
+    common_config.register_common_config_options()
     common_config.init(sys.argv[1:])
     asr1k_config.register_common_opts()
     asr1k_config.register_l2_opts()


### PR DESCRIPTION
From upstream commit 4d3a2747 fixing bug (#1968606), registration of the group DEFAULT does not happen automatically anymore.

If not loaded, agent fails with 'oslo_config.cfg.NoSuchOptError: no such option api_extensions_path in group [DEFAULT]'