### PR TITLE
Drop all compatibility for pre 17.6 fw versions

### DIFF
--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -30,7 +30,6 @@ DEVICE_OPTS = [
     cfg.IntOpt('nc_timeout', default=5, help='Netconf-YANG timeout, default 5s'),
     cfg.StrOpt('user_name', default='admin', help='Netconf-YANG User'),
     cfg.StrOpt('password', default='secret', help='Netconf-YANG Password'),
-    cfg.BoolOpt('use_bdvif', default=True, help='Use BD-VIF when supported by device firmware'),
 ]
 
 ASR1K_OPTS = [

--- a/asr1k_neutron_l3/models/asr1k_pair.py
+++ b/asr1k_neutron_l3/models/asr1k_pair.py
@@ -29,7 +29,7 @@ LOG = logging.getLogger(__name__)
 class ASR1KContextBase(object):
     @property
     def use_bdvif(self):
-        return self.version_min_17_3
+        return True
 
     @property
     def bd_iftype(self):
@@ -44,10 +44,8 @@ class FakeASR1KContext(ASR1KContextBase):
     stable results
     """
 
-    def __init__(self, version_min_17_3=True, version_min_17_6=True, version_min_17_13=True, version_min_17_15=True,
+    def __init__(self, version_min_17_13=True, version_min_17_15=True,
                  has_stateless_nat=True):
-        self.version_min_17_3 = version_min_17_3
-        self.version_min_17_6 = version_min_17_6
         self.version_min_17_13 = version_min_17_13
         self.version_min_17_15 = version_min_17_15
         self._has_stateless_nat = has_stateless_nat
@@ -58,8 +56,6 @@ class FakeASR1KContext(ASR1KContextBase):
 
 
 class ASR1KContext(ASR1KContextBase):
-    version_min_17_3 = property(lambda self: self._get_version_attr('_version_min_17_3'))
-    version_min_17_6 = property(lambda self: self._get_version_attr('_version_min_17_6'))
     version_min_17_13 = property(lambda self: self._get_version_attr('_version_min_17_13'))
     version_min_17_15 = property(lambda self: self._get_version_attr('_version_min_17_15'))
     has_stateless_nat = property(lambda self: self._get_version_attr('_has_stateless_nat'))
@@ -108,8 +104,6 @@ class ASR1KContext(ASR1KContextBase):
 
             ver = tuple(_to_int_if_possible(d) for d in ver)
 
-            self._version_min_17_3 = ver >= (17, 3)
-            self._version_min_17_6 = ver >= (17, 6)
             self._version_min_17_13 = ver >= (17, 13)
             self._version_min_17_15 = ver >= (17, 15)
             self._has_stateless_nat = ver >= (17, 4)
@@ -137,7 +131,7 @@ class ASR1KContext(ASR1KContextBase):
 
     @property
     def use_bdvif(self):
-        return self.version_min_17_3 and self._use_bdvif and not self.force_bdi
+        return self._use_bdvif and not self.force_bdi
 
     def mark_alive(self, alive):
         if not alive:

--- a/asr1k_neutron_l3/models/asr1k_pair.py
+++ b/asr1k_neutron_l3/models/asr1k_pair.py
@@ -27,13 +27,7 @@ LOG = logging.getLogger(__name__)
 
 
 class ASR1KContextBase(object):
-    @property
-    def use_bdvif(self):
-        return True
-
-    @property
-    def bd_iftype(self):
-        return "BD-VIF" if self.use_bdvif else "BDI"
+    pass
 
 
 class FakeASR1KContext(ASR1KContextBase):
@@ -60,17 +54,15 @@ class ASR1KContext(ASR1KContextBase):
     version_min_17_15 = property(lambda self: self._get_version_attr('_version_min_17_15'))
     has_stateless_nat = property(lambda self: self._get_version_attr('_has_stateless_nat'))
 
-    def __init__(self, name, host, yang_port, nc_timeout, username, password, use_bdvif, insecure=True,
-                 force_bdi=False, headers={}):
+    def __init__(self, name, host, yang_port, nc_timeout, username, password, insecure=True,
+                 headers={}):
         self.name = name
         self.host = host
         self.yang_port = yang_port
         self.nc_timeout = nc_timeout
         self.username = username
         self.password = password
-        self._use_bdvif = use_bdvif
         self.insecure = insecure
-        self.force_bdi = force_bdi
         self.headers = headers
         self.headers['content-type'] = headers.get('content-type', "application/yang-data+json")
         self.headers['accept'] = headers.get('accept', "application/yang-data+json")
@@ -129,10 +121,6 @@ class ASR1KContext(ASR1KContextBase):
             time.sleep(1)
         return False
 
-    @property
-    def use_bdvif(self):
-        return self._use_bdvif and not self.force_bdi
-
     def mark_alive(self, alive):
         if not alive:
             LOG.debug("Device %s marked as dead, resetting version info", self.host)
@@ -158,7 +146,7 @@ class ASR1KPair(object):
 
         for device_name, config in device_config.items():
             asr1kctx = ASR1KContext(device_name, config.host, config.yang_port, config.nc_timeout,
-                                    config.user_name, config.password, config.use_bdvif,
+                                    config.user_name, config.password,
                                     insecure=True)
 
             self.contexts.append(asr1kctx)

--- a/asr1k_neutron_l3/models/netconf_yang/access_list.py
+++ b/asr1k_neutron_l3/models/netconf_yang/access_list.py
@@ -87,7 +87,6 @@ class AccessList(NyBase):
         return [
             {"key": "name", "id": True},
             {'key': 'rules', 'yang-key': "access-list-seq-rule", 'type': [ACLRule], 'default': []},
-            {'key': 'drop_on_17_3', 'default': False},
         ]
 
     @classmethod
@@ -132,9 +131,6 @@ class AccessList(NyBase):
         self.rules.append(rule)
 
     def to_dict(self, context):
-        if context.version_min_17_3 and self.drop_on_17_3:
-            return {ACLConstants.EXTENDED: {}}
-
         entry = OrderedDict()
         entry[ACLConstants.NAME] = self.name
         # entry[ACLConstants.ACL_RULE]=self.rules
@@ -150,9 +146,6 @@ class AccessList(NyBase):
 
     @execute_on_pair()
     def update(self, context):
-        if context.version_min_17_3 and self.drop_on_17_3:
-            return None
-
         # we need to check if the ACL needs to be updated, if it does selectively delete,
         # because we can't easily update individual rules
         if len(self._internal_validate(context=context)) > 0:
@@ -170,8 +163,7 @@ class AccessList(NyBase):
         if self.policy_id:
             return False
 
-        return context.version_min_17_3 and \
-            (self.drop_on_17_3 or self.name.startswith("PBR-") and self.neutron_router_id is not None) or \
+        return (self.name.startswith("PBR-") and self.neutron_router_id is not None) or \
             super(AccessList, self).is_orphan(*args, context=context, **kwargs)
 
 

--- a/asr1k_neutron_l3/models/netconf_yang/copy_config.py
+++ b/asr1k_neutron_l3/models/netconf_yang/copy_config.py
@@ -9,12 +9,6 @@ from asr1k_neutron_l3.common.prometheus_monitor import PrometheusMonitor
 class CopyConfig(NyBase):
     COPY = """
     <copy xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-rpc">
-        <_source>{source}</_source>
-        <_destination>{destination}</_destination>
-    </copy>"""
-
-    COPY_17_3 = """
-    <copy xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-rpc">
         <source-drop-node-name>{source}</source-drop-node-name>
         <destination-drop-node-name>{destination}</destination-drop-node-name>
     </copy>"""
@@ -30,11 +24,7 @@ class CopyConfig(NyBase):
                                                                  entity=self.__class__.__name__,
                                                                  action='copy').time():
                 with ConnectionManager(context=context) as connection:
-                    if context.version_min_17_3:
-                        COPY_CMD = self.COPY_17_3
-                    else:
-                        COPY_CMD = self.COPY
-                    result = connection.rpc(COPY_CMD.format(source=source, destination=destination),
+                    result = connection.rpc(self.COPY.format(source=source, destination=destination),
                                             entity=self.__class__.__name__,
                                             action='copy')
                     parsed = etree.fromstring(result._raw.encode())

--- a/asr1k_neutron_l3/models/netconf_yang/l2_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l2_interface.py
@@ -116,8 +116,6 @@ class BridgeDomain(NyBase):
 
     def preflight(self, context):
         """Remove wrong interface membership for all BD-VIF members"""
-        if not context.version_min_17_3:
-            return
 
         # go through all non-deleted member interfaces
         for bdvif in self.bdvif_members:
@@ -166,22 +164,16 @@ class BridgeDomain(NyBase):
         bddef[xml_utils.NS] = xml_utils.NS_CISCO_BRIDGE_DOMAIN
         bddef[L2Constants.BRIDGE_DOMAIN_ID] = self.id
 
-        if context.version_min_17_3:
-            if context.use_bdvif:
-                bddef[L2Constants.MEMBER] = {
-                    L2Constants.MEMBER_IFACE: [_m.to_dict(context)
-                                               for _m in sorted(self.if_members,
-                                                                key=lambda _x: _x.interface)],
-                    L2Constants.MEMBER_BDVIF: [_m.to_dict(context)
-                                               for _m in sorted(self.bdvif_members, key=attrgetter('name'))],
-                }
-                if self.has_complete_member_config:
-                    bddef[L2Constants.MEMBER][xml_utils.OPERATION] = NC_OPERATION.PUT
-            else:
-                # This can be used for migrating back from new-style bridges, but might bring some problems
-                # if the bridge was never used as a new-stlye bridge
-                # bddef[L2Constants.MEMBER] = {xml_utils.OPERATION: NC_OPERATION.DELETE}
-                pass
+        if context.use_bdvif:
+            bddef[L2Constants.MEMBER] = {
+                L2Constants.MEMBER_IFACE: [_m.to_dict(context)
+                                           for _m in sorted(self.if_members,
+                                                            key=lambda _x: _x.interface)],
+                L2Constants.MEMBER_BDVIF: [_m.to_dict(context)
+                                           for _m in sorted(self.bdvif_members, key=attrgetter('name'))],
+            }
+            if self.has_complete_member_config:
+                bddef[L2Constants.MEMBER][xml_utils.OPERATION] = NC_OPERATION.PUT
 
         return {L2Constants.BRIDGE_DOMAIN_BRIDGE_ID: bddef}
 

--- a/asr1k_neutron_l3/models/netconf_yang/l2_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l2_interface.py
@@ -18,7 +18,6 @@ from operator import attrgetter
 from collections import OrderedDict
 from oslo_log import log as logging
 
-from asr1k_neutron_l3.common import utils
 from asr1k_neutron_l3.models.netconf_yang.ny_base import NC_OPERATION, NyBase, execute_on_pair
 from asr1k_neutron_l3.models.netconf_yang import xml_utils
 from asr1k_neutron_l3.plugins.db import asr1k_db
@@ -163,22 +162,20 @@ class BridgeDomain(NyBase):
         bddef = OrderedDict()
         bddef[xml_utils.NS] = xml_utils.NS_CISCO_BRIDGE_DOMAIN
         bddef[L2Constants.BRIDGE_DOMAIN_ID] = self.id
-
-        if context.use_bdvif:
-            bddef[L2Constants.MEMBER] = {
-                L2Constants.MEMBER_IFACE: [_m.to_dict(context)
-                                           for _m in sorted(self.if_members,
-                                                            key=lambda _x: _x.interface)],
-                L2Constants.MEMBER_BDVIF: [_m.to_dict(context)
-                                           for _m in sorted(self.bdvif_members, key=attrgetter('name'))],
-            }
-            if self.has_complete_member_config:
-                bddef[L2Constants.MEMBER][xml_utils.OPERATION] = NC_OPERATION.PUT
+        bddef[L2Constants.MEMBER] = {
+            L2Constants.MEMBER_IFACE: [_m.to_dict(context)
+                                       for _m in sorted(self.if_members,
+                                                        key=lambda _x: _x.interface)],
+            L2Constants.MEMBER_BDVIF: [_m.to_dict(context)
+                                       for _m in sorted(self.bdvif_members, key=attrgetter('name'))],
+        }
+        if self.has_complete_member_config:
+            bddef[L2Constants.MEMBER][xml_utils.OPERATION] = NC_OPERATION.PUT
 
         return {L2Constants.BRIDGE_DOMAIN_BRIDGE_ID: bddef}
 
     def _diff(self, context, device_config):
-        if context.use_bdvif and device_config and not self.has_complete_member_config:
+        if device_config and not self.has_complete_member_config:
             # we don't know all bd-vif members - the diff should represent if
             # the bd-vifs we know about are configured
             neutron_bdvif_names = [_m.name for _m in self.bdvif_members]
@@ -394,8 +391,6 @@ class ServiceInstance(NyBase):
         instance[L2Constants.ENCAPSULATION] = OrderedDict()
         instance[L2Constants.ENCAPSULATION][L2Constants.DOT1Q] = dot1q
         instance[L2Constants.REWRITE] = rewrite
-        if not context.use_bdvif:
-            instance[L2Constants.BRIDGE_DOMAIN] = bridge_domain
 
         result = OrderedDict()
         result[L2Constants.SERVICE_INSTANCE] = instance
@@ -430,61 +425,9 @@ class ExternalInterface(ServiceInstance):
             int(self.id) not in all_segmentation_ids
 
 
-class LoopbackExternalInterface(ServiceInstance):
-    PORT_CHANNEL = "2"
-
-    def __init__(self, **kwargs):
-        kwargs['bridge_domain'] = kwargs.get('dot1q')
-        kwargs['dot1q'] = kwargs.get('dot1q')
-        super(LoopbackExternalInterface, self).__init__(**kwargs)
-
-    def to_dict(self, context):
-        if context.use_bdvif:
-            return {}
-        else:
-            return super(LoopbackExternalInterface, self).to_dict(context)
-
-    def is_orphan(self, all_segmentation_ids, all_bd_ids, context, *args, **kwargs):
-        # KeepBDUpInterface is included here, as they share a port-channel
-        return not context.use_bdvif and \
-            (utils.to_bridge_domain(asr1k_db.MIN_SECOND_DOT1Q) <= int(self.id) <=
-             utils.to_bridge_domain(asr1k_db.MAX_SECOND_DOT1Q) and
-             int(self.id) not in all_bd_ids) or \
-            context.use_bdvif and \
-            (asr1k_db.MIN_DOT1Q <= int(self.id) <= asr1k_db.MAX_DOT1Q and
-             int(self.id) not in all_segmentation_ids)
-
-
-class LoopbackInternalInterface(ServiceInstance):
-    PORT_CHANNEL = "3"
-
-    def __init__(self, **kwargs):
-        super(LoopbackInternalInterface, self).__init__(**kwargs)
-
-    def to_dict(self, context):
-        if context.use_bdvif:
-            return {}
-        else:
-            return super(LoopbackInternalInterface, self).to_dict(context)
-
-    def is_orphan(self, all_bd_ids, context, *args, **kwargs):
-        return context.use_bdvif or \
-            (utils.to_bridge_domain(asr1k_db.MIN_SECOND_DOT1Q) <= int(self.id) <=
-             utils.to_bridge_domain(asr1k_db.MAX_SECOND_DOT1Q) and
-             int(self.id) not in all_bd_ids)
-
-
 class KeepBDUpInterface(ServiceInstance):
     PORT_CHANNEL = "2"
 
-    def __init__(self, **kwargs):
-        super(KeepBDUpInterface, self).__init__(**kwargs)
-
-    def to_dict(self, context):
-        if context.use_bdvif:
-            return super(KeepBDUpInterface, self).to_dict(context)
-        else:
-            return {}
-
     def is_orphan(self, all_router_ids, all_segmentation_ids, all_bd_ids, context, *args, **kwargs):
-        raise NotImplementedError("This class' orphan check is handled by LoopbackExternalInterface")
+        return (asr1k_db.MIN_DOT1Q <= int(self.id) <= asr1k_db.MAX_DOT1Q and
+                int(self.id) not in all_segmentation_ids)

--- a/asr1k_neutron_l3/models/netconf_yang/l3_interface_state.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l3_interface_state.py
@@ -1,12 +1,12 @@
-from asr1k_neutron_l3.models.netconf_yang.ny_base import NyBase, execute_on_pair
+from asr1k_neutron_l3.models.netconf_yang.ny_base import NyBase
 from asr1k_neutron_l3.models.netconf_yang import xml_utils
 
 
-class VBInterfaceState(NyBase):
+class BDInterfaceState(NyBase):
     ID_FILTER = """
           <interfaces-state xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces">
             <interface>
-              <name>{iftype}{id}</name>
+              <name>BD-VIF{id}</name>
             </interface>
           </interfaces-state>
     """
@@ -38,14 +38,6 @@ class VBInterfaceState(NyBase):
             {'key': 'out_discards', 'yang-key': 'out-discards', 'yang-path': 'statistics'},
             {'key': 'out_errors', 'yang-key': 'out-errors', 'yang-path': 'statistics'},
         ]
-
-    def __init__(self, **kwargs):
-        super(VBInterfaceState, self).__init__(**kwargs)
-
-    @classmethod
-    @execute_on_pair()
-    def get(cls, id=None, port_channel=None, context=None):
-        return cls._get(id=id, iftype=context.bd_iftype, context=context)
 
     @classmethod
     def _remove_base_wrapper(cls, dict, context):

--- a/asr1k_neutron_l3/models/netconf_yang/nat.py
+++ b/asr1k_neutron_l3/models/netconf_yang/nat.py
@@ -314,7 +314,7 @@ class InterfaceDynamicNat(DynamicNat):
         self.redundancy = None
 
     def to_dict(self, context):
-        ifname = "{}{}".format(context.bd_iftype, self.bd)
+        ifname = f"BD-VIF{self.bd}"
         vrf = {
             NATConstants.NAME: self.vrf,
         }

--- a/asr1k_neutron_l3/models/netconf_yang/nat.py
+++ b/asr1k_neutron_l3/models/netconf_yang/nat.py
@@ -748,14 +748,13 @@ class StaticNat(NyBase):
         entry[NATConstants.MATCH_IN_VRF] = ""
 
         if not self.from_device:
-            if context.version_min_17_6 or (self.stateless and context.has_stateless_nat):
+            if self.stateless and context.has_stateless_nat:
                 entry[NATConstants.STATELESS] = ""
             elif self.redundancy is not None:
                 # only set redundancy if we should not or cannot enable stateless
                 entry[NATConstants.REDUNDANCY] = self.redundancy
                 entry[NATConstants.MAPPING_ID] = self.mapping_id
-            if context.version_min_17_6:
-                entry[NATConstants.NO_ALIAS] = ""
+            entry[NATConstants.NO_ALIAS] = ""
         else:
             if self.stateless:
                 entry[NATConstants.STATELESS] = ""

--- a/asr1k_neutron_l3/models/netconf_yang/route_map.py
+++ b/asr1k_neutron_l3/models/netconf_yang/route_map.py
@@ -91,7 +91,7 @@ class RouteMap(NyBase):
         map[RouteMapConstants.NAME] = self.name
         map[RouteMapConstants.ROUTE_MAP_SEQ] = []
         for item in self.seq:
-            if item is not None and not item.drop_on_17_3:
+            if item is not None:
                 map[RouteMapConstants.ROUTE_MAP_SEQ].append(item.to_dict(context=context))
 
         result[self.ITEM_KEY] = map
@@ -135,7 +135,6 @@ class MapSequence(NyBase):
             {'key': 'prefix_list', 'yang-key': 'prefix-list', 'yang-path': 'match/ip/address'},
             {'key': 'access_list', 'yang-key': 'access-list', 'yang-path': 'match/ip/address'},
             {'key': 'ip_precedence', 'yang-path': 'set/ip/precedence', 'yang-key': 'precedence-fields'},
-            {'key': 'drop_on_17_3', 'default': False},
         ]
 
     def __init__(self, **kwargs):

--- a/asr1k_neutron_l3/models/netconf_yang/vrf.py
+++ b/asr1k_neutron_l3/models/netconf_yang/vrf.py
@@ -23,7 +23,7 @@ from asr1k_neutron_l3.models.netconf_yang.bgp import AddressFamily
 from asr1k_neutron_l3.common import cli_snippets
 from asr1k_neutron_l3.common import utils
 from asr1k_neutron_l3.models.connection import ConnectionManager
-from asr1k_neutron_l3.models.netconf_yang.l3_interface import VBInterface
+from asr1k_neutron_l3.models.netconf_yang.l3_interface import BDInterface
 from asr1k_neutron_l3.models.netconf_yang.nat import InterfaceDynamicNat
 from asr1k_neutron_l3.models.netconf_yang.ny_base import NyBase, Requeable, NC_OPERATION, execute_on_pair, \
     retry_on_failure
@@ -245,20 +245,20 @@ class VrfDefinition(NyBase, Requeable):
             LOG.error("Failed to delete {} routes in VRF {} postlight : {}".format(len(routes), self.id, e))
 
         LOG.debug("Processing Interfaces")
-        vbis = []
+        bdifs = []
         try:
-            vbis = VBInterface.get_for_vrf(context=context, vrf=self.id)
-            if len(vbis) == 0:
+            bdifs = BDInterface.get_for_vrf(context=context, vrf=self.id)
+            if len(bdifs) == 0:
                 LOG.info("No interfaces to clean")
 
-            for vbi in vbis:
-                LOG.info("Deleting hanging interface {}{} in vrf {} postflight."
-                         .format(context.bd_iftype, vbi.name, self.name))
-                vbi._delete(context=context)
-                LOG.info("Deleted hanging interface {}{} in vrf {} postflight."
-                         .format(context.bd_iftype, vbi.name, self.name))
+            for bdif in bdifs:
+                LOG.info("Deleting hanging interface BD-VIF%s in vrf %s postflight.",
+                         bdif.name, self.name)
+                bdif._delete(context=context)
+                LOG.info("Deleted hanging interface BD-VIF%s in vrf %s postflight.",
+                         bdif.name, self.name)
         except BaseException as e:
-            LOG.error("Failed to delete {} intefaces in VRF {} postlight : {}".format(len(vbis), self.id, e))
+            LOG.error("Failed to delete {} intefaces in VRF {} postlight : {}".format(len(bdifs), self.id, e))
 
         LOG.debug("Processing Address Families")
         afs = []

--- a/asr1k_neutron_l3/models/netconf_yang/vrf.py
+++ b/asr1k_neutron_l3/models/netconf_yang/vrf.py
@@ -291,15 +291,7 @@ class IpV4AddressFamily(NyBase):
     def __parameters__(cls):
         return [
             {'key': 'map', 'yang-path': "export", "default": None},
-            {'key': 'map_17_3', 'default': None},
 
-            # =16.9
-            {'key': 'rt_export', 'yang-key': "export", 'yang-path': "route-target",
-             'type': [RouteTarget], "default": []},
-            {'key': 'rt_import', 'yang-key': "import", 'yang-path': "route-target",
-             'type': [RouteTarget], "default": []},
-
-            # >16.9
             {'key': 'rt_export', 'yang-key': "without-stitching",
              'yang-path': "route-target/export-route-target",
              'type': [RouteTarget], "default": []},
@@ -312,10 +304,7 @@ class IpV4AddressFamily(NyBase):
         address_family = OrderedDict()
 
         if self.map is not None:
-            export_map = self.map
-            if not self.from_device and context.version_min_17_3 and self.map_17_3:
-                export_map = self.map_17_3
-            address_family[VrfConstants.EXPORT] = {"map": export_map}
+            address_family[VrfConstants.EXPORT] = {"map": self.map}
 
         address_family[VrfConstants.ROUTE_TARGET] = {}
 
@@ -324,10 +313,7 @@ class IpV4AddressFamily(NyBase):
             for rt in sorted(self.rt_export, key=attrgetter('normalized_asn_ip')):
                 asns.append(rt.to_dict(context))
 
-            if context.version_min_17_3:
-                rt = {VrfConstants.ROUTE_TARGET_EXPORT: {VrfConstants.WITHOUT_STITCHING: asns}}
-            else:
-                rt = {VrfConstants.EXPORT: asns}
+            rt = {VrfConstants.ROUTE_TARGET_EXPORT: {VrfConstants.WITHOUT_STITCHING: asns}}
             address_family[VrfConstants.ROUTE_TARGET].update(rt)
 
         if self.rt_import:
@@ -335,10 +321,7 @@ class IpV4AddressFamily(NyBase):
             for rt in sorted(self.rt_import, key=attrgetter('normalized_asn_ip')):
                 asns.append(rt.to_dict(context))
 
-            if context.version_min_17_3:
-                rt = {VrfConstants.ROUTE_TARGET_IMPORT: {VrfConstants.WITHOUT_STITCHING: asns}}
-            else:
-                rt = {VrfConstants.IMPORT: asns}
+            rt = {VrfConstants.ROUTE_TARGET_IMPORT: {VrfConstants.WITHOUT_STITCHING: asns}}
             address_family[VrfConstants.ROUTE_TARGET].update(rt)
 
         return dict(address_family)

--- a/asr1k_neutron_l3/models/neutron/l2/bridgedomain.py
+++ b/asr1k_neutron_l3/models/neutron/l2/bridgedomain.py
@@ -105,7 +105,7 @@ class BridgeDomain(object):
                                                                       .format(self.network_id)
                                                                       if self.network_id else None)
 
-        # process ports (16.9: build hyperloop, 17.3: build bdvif members)
+        # process ports (17.3+: build bdvif members)
         self.lb_ext_ifaces = []
         self.lb_int_ifaces = []
         self.if_members = [
@@ -121,22 +121,6 @@ class BridgeDomain(object):
             second_dot1q = port['second_dot1q']
             int_service_instance = utils.to_bridge_domain(second_dot1q)
 
-            # only used for 16.9
-            lb_ext_iface = l2_interface.LoopbackExternalInterface(id=int_service_instance,
-                                                                  description="Port : {}".format(port['port_id']),
-                                                                  dot1q=self.bd_id,
-                                                                  second_dot1q=second_dot1q,
-                                                                  way=2, mode="symmetric")
-            self.lb_ext_ifaces.append(lb_ext_iface)
-            lb_int_iface = l2_interface.LoopbackInternalInterface(id=int_service_instance,
-                                                                  description="Port : {}".format(port['port_id']),
-                                                                  bridge_domain=int_service_instance,
-                                                                  dot1q=self.bd_id,
-                                                                  second_dot1q=second_dot1q,
-                                                                  way=2, mode="symmetric")
-            self.lb_int_ifaces.append(lb_int_iface)
-
-            # only used for 17.3
             bdvif_member = l2_interface.BDVIFMember(name=int_service_instance)
             self.bdvif_members.append(bdvif_member)
 

--- a/asr1k_neutron_l3/models/neutron/l3/access_list.py
+++ b/asr1k_neutron_l3/models/neutron/l3/access_list.py
@@ -19,15 +19,14 @@ from asr1k_neutron_l3.models.netconf_yang import access_list
 
 
 class AccessList(base.Base):
-    def __init__(self, id, drop_on_17_3=False):
+    def __init__(self, id):
         super().__init__()
         self.id = id
-        self._drop_on_17_3 = drop_on_17_3
         self.rules = []
 
     @property
     def _rest_definition(self):
-        acl = access_list.AccessList(name=self.id, drop_on_17_3=self._drop_on_17_3)
+        acl = access_list.AccessList(name=self.id)
         for i, rule in enumerate(self.rules):
             sequence = (i + 1) * 10
             ace_rule = access_list.ACERule(

--- a/asr1k_neutron_l3/models/neutron/l3/bgp.py
+++ b/asr1k_neutron_l3/models/neutron/l3/bgp.py
@@ -50,7 +50,7 @@ class AddressFamily(base.Base):
             self.enable_bgp = True
 
         self._rest_definition = bgp.AddressFamily(vrf=self.vrf, asn=self.asn, enable_bgp=self.enable_bgp,
-                                                  static=True, connected=True, networks_v4=self.networks_v4)
+                                                  networks_v4=self.networks_v4)
 
     def get(self):
         return bgp.AddressFamily.get(self.vrf, asn=self.asn, enable_bgp=self.enable_bgp)

--- a/asr1k_neutron_l3/models/neutron/l3/route_map.py
+++ b/asr1k_neutron_l3/models/neutron/l3/route_map.py
@@ -70,13 +70,6 @@ class PBRRouteMap(base.Base):
         sequences = []
 
         if gateway_interface is not None:
-            sequences.append(route_map.MapSequence(seq_no=10,
-                                                   operation='permit',
-                                                   access_list='PBR-{}'.format(self.vrf),
-                                                   next_hop=gateway_interface.primary_gateway_ip,
-                                                   ip_precedence='routine',
-                                                   force=True,
-                                                   drop_on_17_3=True))
             sequences.append(route_map.MapSequence(seq_no=15,
                                                    operation='permit',
                                                    ip_precedence='routine'))

--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -91,7 +91,6 @@ class Router(Base):
         self.fwaas_conf, self.fwaas_external_policies = self._build_fwaas_conf()
 
         self.nat_acl = self._build_nat_acl()
-        self.pbr_acl = self._build_pbr_acl()
 
         self.route_map = route_map.RouteMap(self.router_info.get('id'), rt=rt,
                                             routable_interface=self.routable_interface)
@@ -220,20 +219,6 @@ class Router(Base):
             acl.append_rule(access_list.Rule(action='deny'))
         else:
             acl.append_rule(access_list.Rule())
-        return acl
-
-    def _build_pbr_acl(self):
-        acl = access_list.AccessList("PBR-{}".format(utils.uuid_to_vrf_id(self.router_id)), drop_on_17_3=True)
-
-        if self.gateway_interface:
-            subnet = self.gateway_interface.primary_subnet
-
-            if subnet is not None and subnet.get('cidr') is not None:
-                ip, netmask = utils.from_cidr(subnet.get('cidr'))
-                wildcard = utils.to_wildcard_mask(netmask)
-                rule = access_list.Rule(destination=ip, destination_mask=wildcard)
-                acl.append_rule(rule)
-
         return acl
 
     def _route_has_connected_interface(self, l3_route):
@@ -429,8 +414,6 @@ class Router(Base):
             results.append(firewall.FirewallVrfPolicer(self.router_id).delete())
             results.append(firewall.Zone(self.router_id).delete())
 
-        if self.pbr_acl:
-            results.append(self.pbr_acl.update())
         # Working assumption is that any NAT mode migration is completed
 
         results.append(self.floating_ips.update())
@@ -490,7 +473,6 @@ class Router(Base):
 
         results.append(self.pbr_route_map.delete())
         results.append(self.nat_acl.delete())
-        results.append(self.pbr_acl.delete())
         results.append(self.bgp_address_family.delete())
 
         for interface in self.interfaces.all_interfaces:

--- a/asr1k_neutron_l3/models/neutron/l3/vrf.py
+++ b/asr1k_neutron_l3/models/neutron/l3/vrf.py
@@ -35,19 +35,16 @@ class Vrf(base.Base):
         self.rd = utils.to_rd(self.asn, rd)
 
         self.enable_bgp = False
-        self.map_17_3 = None
+        self.map = "exp-{}".format(self.name)
         if self.routable_interface:
             self.enable_bgp = True
-            self.map_17_3 = "{}{:02d}".format(cfg.CONF.asr1k_l3.dapnet_rm_prefix, global_vrf_id)
-
-        self.map = "exp-{}".format(self.name)
+            self.map = "{}{:02d}".format(cfg.CONF.asr1k_l3.dapnet_rm_prefix, global_vrf_id)
 
         self.rt_import = [{'asn_ip': asn_ip} for asn_ip in rt_import] if rt_import else None
         self.rt_export = [{'asn_ip': asn_ip} for asn_ip in rt_export] if rt_export else None
 
         self._rest_definition = vrf.VrfDefinition(name=self.name, description=self.description,
-                                                  rd=self.rd, enable_bgp=self.enable_bgp,
-                                                  map=self.map, map_17_3=self.map_17_3,
+                                                  rd=self.rd, enable_bgp=self.enable_bgp, map=self.map,
                                                   rt_import=self.rt_import, rt_export=self.rt_export)
 
     def get(self):

--- a/asr1k_neutron_l3/plugins/l3/agents/device_cleaner.py
+++ b/asr1k_neutron_l3/plugins/l3/agents/device_cleaner.py
@@ -26,10 +26,9 @@ from asr1k_neutron_l3.common import utils
 from asr1k_neutron_l3.models.asr1k_pair import ASR1KPair
 from asr1k_neutron_l3.models.netconf_yang.access_list import AccessList
 from asr1k_neutron_l3.models.netconf_yang.arp import VrfArpList
-from asr1k_neutron_l3.models.netconf_yang.l2_interface import BridgeDomain, LoopbackInternalInterface, \
-    LoopbackExternalInterface, ExternalInterface
+from asr1k_neutron_l3.models.netconf_yang.l2_interface import BridgeDomain, ExternalInterface, KeepBDUpInterface
 from asr1k_neutron_l3.models.netconf_yang.class_map import ClassMap
-from asr1k_neutron_l3.models.netconf_yang.l3_interface import VBInterface
+from asr1k_neutron_l3.models.netconf_yang.l3_interface import BDInterface
 from asr1k_neutron_l3.models.netconf_yang.nat import StaticNat, NatPool, InterfaceDynamicNat, PoolDynamicNat
 from asr1k_neutron_l3.models.netconf_yang.parameter_map import ParameterMapInspectGlobalVrf
 from asr1k_neutron_l3.models.netconf_yang.prefix import Prefix
@@ -57,9 +56,9 @@ class OrphanEncoder(json.JSONEncoder):
 
 class DeviceCleanerMixin(object):
     ENTITIES = [
-        BridgeDomain, LoopbackInternalInterface, LoopbackExternalInterface, ExternalInterface,
+        BridgeDomain, KeepBDUpInterface, ExternalInterface,
         StaticNat, PoolDynamicNat, InterfaceDynamicNat, NatPool,
-        VBInterface,
+        BDInterface,
         RouteMap, Prefix, AccessList, VrfArpList, VrfRoute,
         ZonePair, Zone, ParameterMapInspectGlobalVrf,
         VrfDefinition

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_parsing.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_parsing.py
@@ -87,74 +87,7 @@ class ParsingTest(base.BaseTestCase):
         self.assertEqual(bdif2_ids, [6379, 6383])
 
     def test_vrf_parsing_with_rt(self):
-        vrf_xml_1609_multi = """
-<rpc-reply message-id="urn:uuid:68f753a2-4d41-45ad-98f7-3a6460c8dd9d" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-  <data>
-    <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
-      <vrf>
-        <definition>
-          <name>1ccc4863d8bc4c82affa0cb198e8d5d1</name>
-          <description>Router 1ccc4863-d8bc-4c82-affa-0cb198e8d5d1</description>
-          <rd>65148:871</rd>
-          <address-family>
-            <ipv4>
-              <export>
-                <map>exp-1ccc4863d8bc4c82affa0cb198e8d5d1</map>
-              </export>
-              <route-target>
-                <export>
-                  <asn-ip>4268359684:12345</asn-ip>
-                </export>
-                <export>
-                  <asn-ip>65148:12345</asn-ip>
-                </export>
-                <import>
-                  <asn-ip>4268359685:12345</asn-ip>
-                </import>
-                <import>
-                  <asn-ip>65148:12345</asn-ip>
-                </import>
-              </route-target>
-            </ipv4>
-          </address-family>
-        </definition>
-      </vrf>
-    </native>
-  </data>
-</rpc-reply>
-"""
-        vrf_xml_1609_single = """
-<rpc-reply message-id="urn:uuid:68f753a2-4d41-45ad-98f7-3a6460c8dd9d" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-  <data>
-    <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
-      <vrf>
-        <definition>
-          <name>1ccc4863d8bc4c82affa0cb198e8d5d1</name>
-          <description>Router 1ccc4863-d8bc-4c82-affa-0cb198e8d5d1</description>
-          <rd>65148:871</rd>
-          <address-family>
-            <ipv4>
-              <export>
-                <map>exp-1ccc4863d8bc4c82affa0cb198e8d5d1</map>
-              </export>
-              <route-target>
-                <export>
-                  <asn-ip>4268359684:12345</asn-ip>
-                </export>
-                <import>
-                  <asn-ip>4268359685:12345</asn-ip>
-                </import>
-              </route-target>
-            </ipv4>
-          </address-family>
-        </definition>
-      </vrf>
-    </native>
-  </data>
-</rpc-reply>
-"""
-
-        vrf_xml_1731 = """
+        vrf_xml = """
 <rpc-reply message-id="urn:uuid:d40a38bd-0a67-4f09-86b1-42ea770a8b5e" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
   <data>
     <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
@@ -195,28 +128,18 @@ class ParsingTest(base.BaseTestCase):
 </rpc-reply>
 """
 
-        expected_single = {
-            "rt_export": {"4268359684:12345", },
-            "rt_import": {"4268359685:12345"},
-        }
-        expected_multi = {
+        expected = {
             "rt_export": {"4268359684:12345", "65148:12345"},
             "rt_import": {"4268359685:12345", "65148:12345"},
         }
 
-        context_1609 = FakeASR1KContext(version_min_17_3=False)
-        context_17_3 = FakeASR1KContext(version_min_17_3=True)
+        context = FakeASR1KContext()
 
-        for context, vrf_xml, expected in ((context_1609, vrf_xml_1609_single, expected_single),
-                                           (context_1609, vrf_xml_1609_multi, expected_multi),
-                                           (context_17_3, vrf_xml_1731, expected_multi)):
-            vrf = VrfDefinition.from_xml(vrf_xml, context)
-            self.assertEqual(expected['rt_export'],
-                             set([rt.normalized_asn_ip for rt in vrf.address_family_ipv4.rt_export]),
-                             "rt_export failed for 17_3={}".format(context.version_min_17_3))
-            self.assertEqual(expected['rt_import'],
-                             set([rt.normalized_asn_ip for rt in vrf.address_family_ipv4.rt_import]),
-                             "rt_import failed for 17_3={}".format(context.version_min_17_3))
+        vrf = VrfDefinition.from_xml(vrf_xml, context)
+        self.assertEqual(expected['rt_export'],
+                         set([rt.normalized_asn_ip for rt in vrf.address_family_ipv4.rt_export]))
+        self.assertEqual(expected['rt_import'],
+                         set([rt.normalized_asn_ip for rt in vrf.address_family_ipv4.rt_import]))
 
     def test_bgp_parsing(self):
         bgp_xml = """
@@ -643,7 +566,7 @@ class ParsingTest(base.BaseTestCase):
         xml = """
 <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"
            message-id="urn:uuid:37bffcac-d037-48c6-b382-f29aaeddaa4a">
-<data> 
+<data>
   <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
     <parameter-map>
       <type>
@@ -759,7 +682,7 @@ class ParsingTest(base.BaseTestCase):
         self.assertEqual("default", zone_pair.source)
         self.assertEqual("ZN-FWAAS-123", zone_pair.destination)
         self.assertEqual("SP-FWAAS-ALLOW-INSPECT", zone_pair.service_policy)
-        
+
         xml = """
 <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"
         message-id="urn:uuid:37bffcac-d037-48c6-b382-f29aaeddaa4a">

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_serialization.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_serialization.py
@@ -12,7 +12,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from copy import deepcopy
 import xmltodict
 
 from neutron.tests import base
@@ -30,12 +29,8 @@ class SerializationTest(base.BaseTestCase):
             match_in_vrf=True
         )
         sn_stateless = StaticNat(**sn_args, stateless=True)
-        sn = StaticNat(**sn_args, stateless=False)
-
-        context_17_3 = FakeASR1KContext(version_min_17_3=True, version_min_17_6=False, version_min_17_13=False)
-        context_17_6 = FakeASR1KContext(version_min_17_3=True, version_min_17_6=True, version_min_17_13=False)
-
-        expected_17_3 = xmltodict.parse("""
+        context_17_6 = FakeASR1KContext(version_min_17_13=False, version_min_17_15=False)
+        expected = xmltodict.parse("""
                             <nat-static-transport-list-with-vrf>
                                 <local-ip>10.10.23.12</local-ip>
                                 <global-ip>192.168.23.12</global-ip>
@@ -43,22 +38,14 @@ class SerializationTest(base.BaseTestCase):
                                 <match-in-vrf></match-in-vrf>
                             </nat-static-transport-list-with-vrf>""")[NATConstants.TRANSPORT_LIST]
 
-        for k in expected_17_3:
-            if expected_17_3[k] is None:
-                expected_17_3[k] = ''
+        for k in expected:
+            if expected[k] is None:
+                expected[k] = ''
 
-        expected_stateless_17_3 = deepcopy(expected_17_3)
-        expected_stateless_17_3['stateless'] = ''
+        expected['stateless'] = ''
+        expected['no-alias'] = ''
 
-        expected_17_6 = deepcopy(expected_stateless_17_3)
-        expected_17_6['no-alias'] = ''
-
-        self.assertEqual(expected_17_3, sn.to_single_dict(context_17_3))
-        self.assertEqual(expected_stateless_17_3,
-                         sn_stateless.to_single_dict(context_17_3))
-
-        self.assertEqual(expected_17_6, sn.to_single_dict(context_17_6))
-        self.assertEqual(expected_17_6,
+        self.assertEqual(expected,
                          sn_stateless.to_single_dict(context_17_6))
 
     def test_static_nat_garp_flag(self):


### PR DESCRIPTION
We are now on version >= 17.6 everywhere and therefore we can drop all code for previous versions (16.9, 17.3). This also makes writing new code easier, as we have to consider (and test) less versions (and even don't have any devices anymore to test the old code).

~~For now I left the BDI code intact, as my main goal was to get rid of all version_min_17_x and drop_on_17_x, but we can also think about removing that in the future.~~ BDI code has been removed in second commit.