### PR TITLE
Readding get_for_vrf() for InterfaceDynamicNat

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/nat.py
+++ b/asr1k_neutron_l3/models/netconf_yang/nat.py
@@ -268,6 +268,9 @@ class InterfaceDynamicNat(DynamicNat):
 
     VRF_XPATH_FILTER = "/native/ip/nat/inside/source/list-interface/list[id='NAT-{vrf}']"
 
+    def get_for_vrf(cls, context, vrf=None):
+        return cls._get_all(context=context, xpath_filter=cls.VRF_XPATH_FILTER.format(vrf=vrf))
+
     @classmethod
     def __parameters__(cls):
         return [


### PR DESCRIPTION
As part of the NAT 17.15 compatibility code in
081c65dbd7bab1f0b7bf31021069eed27d7259e6 get_for_vrf() was accidentally removed. Due to this, the postflight() of the VrfDefinition can no longer properly delete hanging NAT statements (as due to the missing method they can no longer be fetched from the device). Thanks to the rather broad exception handling, the result is that we loose our safety net for hanging NAT statements and have a pretty noisy driver. Hanging NAT "should" only happen in case of excessive locking of the device firmware or something else going wrong in device communication and should not be the default case.

To fix this, we reintroduce get_for_vrf().