### PR TITLE
Readd @classmethod decorator to get_for_vrf()

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/nat.py
+++ b/asr1k_neutron_l3/models/netconf_yang/nat.py
@@ -268,6 +268,7 @@ class InterfaceDynamicNat(DynamicNat):
 
     VRF_XPATH_FILTER = "/native/ip/nat/inside/source/list-interface/list[id='NAT-{vrf}']"
 
+    @classmethod
     def get_for_vrf(cls, context, vrf=None):
         return cls._get_all(context=context, xpath_filter=cls.VRF_XPATH_FILTER.format(vrf=vrf))
 


### PR DESCRIPTION
Commit be552792eed2acc124cb509f3b7f805993b716fd readded get_for_vrf() but forgot to add the @classmethod decorator that is required by the method to work.