### PR TITLE
[Caracal] Adapt Tox and Github Workflow &  [Caracal] Fix Unit Tests

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -2,14 +2,14 @@ name: run-tox
 on:
   push:
     branches:
-      - stable/yoga-m3
+      - stable/2024.1-m3
   pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8]
+        python: ['3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox
-        run: pip install "tox<4.0"
+        run: pip install tox
       - name: Run Tox
         run: "tox -e py"

--- a/asr1k_neutron_l3/tests/common/fixtures.py
+++ b/asr1k_neutron_l3/tests/common/fixtures.py
@@ -154,7 +154,7 @@ class RouterWithSyncDataTestCase(test_address_scope.AddressScopeTestCase,
         network_id = subnet['subnet']['network_id']
         with self.port(subnet=subnet, device_owner="network:router_interface") as port:
             port_id = port['port']['id']
-            self._router_interface_action('add', router_id, None, port_id)
+            self._router_interface_action('add', router_id, None, port_id, as_admin=True)
 
             ctx = context.get_admin_context()
             netseg = self._make_port_binding(ctx, port['port']['id'], self.default_host, network_id,
@@ -178,7 +178,7 @@ class RouterWithSyncDataTestCase(test_address_scope.AddressScopeTestCase,
         ctx = context.get_admin_context()
         with mock.patch.object(asr1k_db.DBPlugin, 'get_network_port_count_per_agent',
                                return_value={'fake-agent': 0}):
-            with self.router(admin_state_up=admin_state_up, tenant_id=tenant_id,
+            with self.router(as_admin=True, admin_state_up=admin_state_up, tenant_id=tenant_id,
                              external_gateway_info=external_gateway_info, **kwargs) as router:
                 pass
 

--- a/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_router.py
+++ b/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_router.py
@@ -44,8 +44,8 @@ class TestRouterClass(RouterWithSyncDataTestCase):
                 self.subnetpool(["10.100.0.0/22"], name="yellow-legged-gull",
                                 address_scope_id=addr_scope['address_scope']['id'],
                                 tenant_id=uuidutils.generate_uuid(), admin=True) as sn_pool, \
-                self.subnet(cidr="10.100.1.0/24", subnetpool_id=sn_pool['subnetpool']['id']) as s_ext, \
-                self.subnet(cidr="10.100.2.0/24", subnetpool_id=sn_pool['subnetpool']['id']) as s_dap, \
+                self.subnet(cidr="10.100.1.0/24", subnetpool_id=sn_pool['subnetpool']['id'], as_admin=True) as s_ext, \
+                self.subnet(cidr="10.100.2.0/24", subnetpool_id=sn_pool['subnetpool']['id'], as_admin=True) as s_dap, \
                 self.subnet(cidr="10.200.0.0/24") as s_int:
             self._set_net_external(s_ext['subnet']['network_id'])
             router = self.make_router_extended(name="r1", ext_subnet=s_ext, int_subnets=[s_dap, s_int])
@@ -69,10 +69,10 @@ class TestRouterClass(RouterWithSyncDataTestCase):
                                 address_scope_id=addr_scope['address_scope']['id'],
                                 tenant_id=uuidutils.generate_uuid(), admin=True) as sn_pool, \
                 self.subnet(cidr="2001:db8:101:11a1::/64", subnetpool_id=sn_pool['subnetpool']['id'],
-                            ip_version=6) as s_ext, \
+                            ip_version=6, as_admin=True) as s_ext, \
                 self.subnet(cidr="2001:db8:101:11b2::/64", subnetpool_id=sn_pool['subnetpool']['id'],
-                            ip_version=6) as s_dap, \
-                self.subnet(cidr="fd00:1234:5678::/64", ip_version=6) as s_int:
+                            ip_version=6, as_admin=True) as s_dap, \
+                self.subnet(cidr="fd00:1234:5678::/64", ip_version=6, as_admin=True) as s_int:
             self._set_net_external(s_ext['subnet']['network_id'])
             router = self.make_router_extended(name="r1", ext_subnet=s_ext, int_subnets=[s_dap, s_int])
             dev_router = self._get_ny_router(router['router']['id'])

--- a/asr1k_neutron_l3/tests/unit/plugins/l3/service_plugins/test_l3_extension_adapter.py
+++ b/asr1k_neutron_l3/tests/unit/plugins/l3/service_plugins/test_l3_extension_adapter.py
@@ -42,7 +42,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
         expected_value = [('name', name), ('tenant_id', tenant_id),
                           ('admin_state_up', True), ('status', 'ACTIVE'),
                           ('external_gateway_info', None)]
-        with self.router(name=name, admin_state_up=True,
+        with self.router(name=name, as_admin=True, admin_state_up=True,
                          tenant_id=tenant_id) as router:
             for k, v in expected_value:
                 self.assertEqual(v, router['router'][k])
@@ -52,7 +52,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
 
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -77,7 +77,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
 
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'ip_address': "10.100.1.6"},
@@ -102,7 +102,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
 
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'ip_address': "10.100.1.6"},
@@ -118,7 +118,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
     def test_router_create_with_extended_nat_pool_with_specific_ips_with_one_ip_duplicated(self, pc_mock):
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'ip_address': "10.100.1.6"},
@@ -137,7 +137,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
 
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'ip_address': "10.100.1.6"},
@@ -160,7 +160,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
     def test_router_create_with_extended_nat_pool_non_consecutive_specified_nat_pool(self, pc_mock):
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'ip_address': "10.100.1.5"},
@@ -176,7 +176,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
     def test_router_create_with_extended_nat_pool_mixed_specified_pool(self, pc_mock):
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'ip_address': "10.100.1.6"},
@@ -193,7 +193,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
             self._set_net_external(net['network']['id'])
             with self.subnet(cidr="10.100.1.0/24", network=net) as s1, \
                     self.subnet(cidr="10.100.4.0/24", network=net) as s2:
-                with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+                with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                                  external_gateway_info={'network_id': net['network']['id'],
                                                         'external_fixed_ips': [
                                                             {'subnet_id': s1['subnet']['id']},
@@ -206,7 +206,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
     def test_router_create_with_extended_nat_pool_too_small(self, pc_mock):
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -218,7 +218,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
     def test_router_create_with_extended_nat_pool_and_non_fitting_ips_specified(self, pc_mock):
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'ip_address': "1.1.1.6"},
@@ -235,7 +235,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
                 {'ip_address': '10.100.1.4'}, {'ip_address': '10.100.1.11'}, {'ip_address': '10.100.1.17'},
                 {'ip_address': '10.100.1.24'}, {'ip_address': '10.100.1.29'}])
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -258,7 +258,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
             self._make_port("json", s['subnet']['network_id'], fixed_ips=[
                 {'ip_address': f'10.100.1.{n}'} for n in range(2, 7)])
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -277,7 +277,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
     def test_router_create_with_extended_nat_pool_update_gateway(self, pc_mock):
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -299,7 +299,8 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
                                          {'ip_address': "10.100.1.6"},
                                          {'ip_address': "10.100.1.7"},
                                          {'ip_address': "10.100.1.8"},
-                                         {'subnet_id': s['subnet']['id']}]}}})
+                                         {'subnet_id': s['subnet']['id']}]}}},
+                                 as_admin=True)
 
                 ctx.session.expire_all()
                 router_atts = db.get_router_att(ctx, router['router']['id'])
@@ -310,7 +311,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
 
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -324,7 +325,9 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
                 self.assertEqual("10.100.1.2-10.100.1.5/24", router_atts.dynamic_nat_pool)
 
                 with mock.patch.object(ASR1KPluginBase, 'ensure_default_route_skip_monitoring', autospec=True):
-                    upd_router = self._remove_external_gateway_from_router(router['router']['id'], None)
+                    upd_router = self._update('routers', router['router']['id'],
+                                              {'router': {'external_gateway_info': None}},
+                                              as_admin=True)
 
                 ctx.session.expire_all()
                 router_atts = db.get_router_att(ctx, router['router']['id'])
@@ -338,7 +341,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
             self._make_port("json", s['subnet']['network_id'], fixed_ips=[
                 {'ip_address': '10.100.1.24'}])
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -359,7 +362,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
             self._set_net_external(net['network']['id'])
             with self.subnet(cidr="10.100.1.0/24", network=net) as s1, \
                     self.subnet(cidr="2001:db8::/64", network=net, ip_version=6) as s2:
-                with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+                with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                                  external_gateway_info={'network_id': net['network']['id'],
                                                         'external_fixed_ips': [
                                                             {'subnet_id': s1['subnet']['id']},
@@ -377,7 +380,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
             self._set_net_external(net['network']['id'])
             with self.subnet(cidr="10.100.1.0/24", network=net) as s1, \
                     self.subnet(cidr="2001:db8::/64", network=net, ip_version=6):
-                with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+                with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                                  external_gateway_info={'network_id': net['network']['id'],
                                                         'external_fixed_ips': [
                                                             {'subnet_id': s1['subnet']['id']},
@@ -395,7 +398,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
             self._set_net_external(net['network']['id'])
             with self.subnet(cidr="10.100.1.0/24", network=net) as s1, \
                     self.subnet(cidr="2001:db8::/64", network=net, ip_version=6) as s2:
-                with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+                with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                                  external_gateway_info={'network_id': net['network']['id'],
                                                         'external_fixed_ips': [
                                                             {'subnet_id': s1['subnet']['id']},
@@ -415,7 +418,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
     def test_router_create_two_v6_addresses_fail(self, pc_mock):
         with self.subnet(cidr="2001:db8::/64", ip_version=6) as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -427,7 +430,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
     def test_router_create_non_existant_subnet(self, pc_mock):
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': uuidutils.generate_uuid()},
@@ -441,7 +444,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
             self._make_port("json", s['subnet']['network_id'], fixed_ips=[{'ip_address': '10.100.1.254'}])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -467,7 +470,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
         with self.subnet(cidr="10.100.1.0/24") as s:
             self._set_net_external(s['subnet']['network_id'])
             self._make_port("json", s['subnet']['network_id'], fixed_ips=[{'ip_address': '10.100.1.250'}])
-            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+            with self.router(name="r1", as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                              external_gateway_info={'network_id': s['subnet']['network_id'],
                                                     'external_fixed_ips': [
                                                         {'subnet_id': s['subnet']['id']},
@@ -514,7 +517,7 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
 
             with mock.patch.object(l3_plugin, '_find_gateway_ip_for_dynamic_nat_pool',
                                    side_effect=alloc_last_ip_on_first_try), \
-                    self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+                    self.router(name="r1",  as_admin=True, admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
                                 external_gateway_info={'network_id': s['subnet']['network_id'],
                                                        'external_fixed_ips': [
                                                            {'subnet_id': s['subnet']['id']},

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ tenacity>=6.0.0 # Apache-2.0
 prometheus_client>=0.0.19
 bs4>=0.0.1
 ncclient
-git+https://github.com/sapcc/networking-bgpvpn@stable/yoga-m3#egg=networking-bgpvpn
--e git+https://github.com/sapcc/neutron-fwaas@stable/yoga-m3#egg=neutron_fwaas
+git+https://github.com/sapcc/networking-bgpvpn@stable/2024.1-m3#egg=networking-bgpvpn
+-e git+https://github.com/sapcc/neutron-fwaas@stable/2024.1-m3#egg=neutron_fwaas

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,3 +16,4 @@ requests
 osprofiler
 six
 stestr>=1.0.0 # Apache-2.0
+WebTest>=2.0.27 # MIT

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@ minversion = 3.18.0
 skipsdist = True
 
 [testenv]
-usedevelop = True
 install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
          PYTHONWARNINGS=default::DeprecationWarning
 deps = -r{toxinidir}/test-requirements.txt
-       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/2024.1-m3#egg=neutron}
+       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/2024.1-m3\#egg=neutron}
+       -e .
 whitelist_externals = sh
 commands =
     pip install -U pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-envlist = py38
+envlist = py310
 minversion = 3.18.0
 skipsdist = True
 
 [testenv]
 usedevelop = True
-install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
+install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
          PYTHONWARNINGS=default::DeprecationWarning
 deps = -r{toxinidir}/test-requirements.txt
-       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/yoga-m3#egg=neutron}
+       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/2024.1-m3#egg=neutron}
 whitelist_externals = sh
 commands =
     pip install -U pip


### PR DESCRIPTION
[Caracal] Adapt Tox and Github Workflow
Adapt github workflow python version and branch to the Caracal/2024.1 release.

[Caracal] Fix Unit Tests
With the Caracal release, default policies are activated by default causing our tests to fail error 'PolicyNotAuthorized'. Simply running them as admin fixes the issue.