### PR TITLE
Reintroduce BDInterface.get_for_vrf()

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
@@ -152,6 +152,10 @@ class BDInterface(NyBase):
         if int(self.mtu) > self.MAX_MTU:
             self.mtu = str(self.MAX_MTU)
 
+    @classmethod
+    def get_for_vrf(cls, context, vrf):
+        return cls._get_all(context=context, xpath_filter=cls.VRF_XPATH_FILTER.format(vrf=vrf))
+
     @property
     def neutron_router_id(self):
         if self.vrf:


### PR DESCRIPTION
In the heat of cleaning up the old BDI code and for that matter not needing to parameterize all the get_item/get_filter calls we also accidentally removed the get_for_vrf() call. This might result in that in some cases we don't clean up interfaces properly. This happens on router delete and the exception is caught, so the DeviceCleaner should remove any left over interfaces, but reintroducing the original method is of course the way to go.

By readding get_for_vrf() we no longer see an exception on router delete and everything should get cleaned up properly.