### PR TITLE
Fwaas fix protocol any

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/firewall.py
+++ b/asr1k_neutron_l3/models/neutron/l3/firewall.py
@@ -24,7 +24,7 @@ from asr1k_neutron_l3.models.neutron.l3 import base
 from asr1k_neutron_l3.models.neutron.l3 import access_list
 from asr1k_neutron_l3.models.netconf_yang.class_map import ClassMap as ncClassMap
 from asr1k_neutron_l3.models.netconf_yang.parameter_map \
-        import ParameterMapInspectGlobalVrf as ncParameterMapInspectGlobalVrf
+    import ParameterMapInspectGlobalVrf as ncParameterMapInspectGlobalVrf
 from asr1k_neutron_l3.models.netconf_yang.service_policy import ServicePolicy as ncServicePolicy
 from asr1k_neutron_l3.models.netconf_yang.service_policy import ServicePolicyClass as ncServicePolicyClass
 from asr1k_neutron_l3.models.netconf_yang.zone import Zone as ncZone
@@ -53,9 +53,9 @@ class AccessList(FirewallPolicyMixin, access_list.AccessList):
     PREFIX = const.FWAAS_ACL_PREFIX
 
     ACTIONS = {
-                'allow': 'permit',
-                'deny': 'deny',
-                'reject': 'deny',
+        'allow': 'permit',
+        'deny': 'deny',
+        'reject': 'deny',
     }
 
     MIMIC_STATEFUL_RULES = [
@@ -173,7 +173,7 @@ class ZonePair(FirewallZoneObject):
     @property
     def _rest_definition(self):
         return ncZonePair(id=self.id, source=self.source, destination=self.destination,
-                        service_policy=self.service_policy)
+                          service_policy=self.service_policy)
 
 
 class ZonePairExtEgress(ZonePair):

--- a/asr1k_neutron_l3/models/neutron/l3/firewall.py
+++ b/asr1k_neutron_l3/models/neutron/l3/firewall.py
@@ -84,6 +84,10 @@ class AccessList(FirewallPolicyMixin, access_list.AccessList):
                 'protocol': rule['protocol']
             }
 
+            if rule_args['protocol'] is None:
+                # protocol "any" on IPv4 means we need to specify protocol 'ip'
+                rule_args['protocol'] = 'ip'
+
             # check if there is an IP address/CIDR for each direction
             # if so do the whole mask, wildcard dance
             for direction in ('source', 'destination'):


### PR DESCRIPTION
If the user specifies protocol any via the FWaaS OpenStack API we end up
with a rule having protocol None. With the old behavior this results in
an empty protocol field, which is not accepted by our hardware router.
Hence, we have to provide a protocol for the ACL. If we don't want to
specify an protocol (tcp, udp, icmp), we need to specify the address
family ("ip") instead, so we now default to that value.

Leaving out the protocol tag from the netconf yang, does not work. It is
accepted by the device (i.e. the YANG stack), but with the empty
protocol field, the YANG stack replaces this with the value "any" (which
I would have done as well if I hadn't read the Cisco device help) and
the IOS-XE cli does not accept any as a valid value here, resulting in a
<bad-cli> error.