### PR TITLE
Only delete single prefix list, not all of them

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/prefix.py
+++ b/asr1k_neutron_l3/models/netconf_yang/prefix.py
@@ -153,6 +153,11 @@ class PrefixBase(NyBase):
         else:
             return super()._delete(context=context)
 
+    def _delete_no_retry(self, context, method=NC_OPERATION.DELETE, postflight=True):
+        # override method - we want to have a patch, as due to the new prefix model the delete operation
+        #                   needs to be one level deeper in the xml request (see to_delete_dict())
+        super()._delete_no_retry(context, method=NC_OPERATION.PATCH, postflight=postflight)
+
     def preflight(self, context):
         # delete all rules that should not be on the device (by seq no, rest is done by update-replace)
         # NOTE: if this deletion succeeds and a later update fails we might get in a situation
@@ -180,6 +185,7 @@ class PrefixBase(NyBase):
         prefixes = []
         for seq in self.seq:
             prefixes.append({
+                xml_utils.OPERATION: NC_OPERATION.REMOVE,
                 PrefixConstants.NAME: self.name,
                 PrefixConstants.NUMBER: seq.no,
             })


### PR DESCRIPTION
With the transition to the new prefix list model we got another layer of indirection. The NyBase class by default handles deletes by adding the operation="delete" to the xml tag it considers being the "main" tag for the object. Due to Cisco removing the hierarchical way of handling prefix lists and putting everything into one list, this outermost tag now is the one holding all entries of all prefix lists. A delete operation on that tag results in all entries being deleted.

Here is an example for a config request that looks like it would delete one ipv6 entry, but in fact deletes all of them:
```xml
  <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
    <ipv6>
      <prefix-lists operation="delete">
        <prefixes>
          <name>ext-1bc9cf3742c04f86a2d01ebe513e3287</name>
          <no>10</no>
        </prefixes>
      </prefix-lists>
    </ipv6>
  </native>
</config>
```

To fix this we need to move the operation away from the <prefix-lists> tag into the <prefixes> tag, like this:
```xml
<config>
  <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
    <ipv6>
      <prefix-lists>
        <prefixes operation="remove">
          <name>ext-1bc9cf3742c04f86a2d01ebe513e3287</name>
          <no>10</no>
        </prefixes>
      </prefix-lists>
    </ipv6>
  </native>
</config>
```

We also switch the operation from "delete" (delete the entry, throw an error if it is not present) to "remove" (delete the entry, ignore if it is not present).

This bug was introduced in c626065 when migrating on the new prefix list model.