### PR TITLE
Delete empty prefix lists on extisting routers

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/prefix.py
+++ b/asr1k_neutron_l3/models/netconf_yang/prefix.py
@@ -16,7 +16,7 @@
 
 from oslo_log import log as logging
 
-from asr1k_neutron_l3.models.netconf_yang.ny_base import execute_on_pair, NC_OPERATION, NyBase
+from asr1k_neutron_l3.models.netconf_yang.ny_base import NC_OPERATION, NyBase
 from asr1k_neutron_l3.models.netconf_yang import xml_utils
 from asr1k_neutron_l3.common import utils
 
@@ -145,13 +145,6 @@ class PrefixBase(NyBase):
         if seq.no is None:
             seq.no = (len(self.seq) + 1) * 10
         self.seq.append(seq)
-
-    @execute_on_pair()
-    def update(self, context):
-        if len(self.seq) > 0:
-            return super()._update(context=context)
-        else:
-            return super()._delete(context=context)
 
     def _delete_no_retry(self, context, method=NC_OPERATION.DELETE, postflight=True):
         # override method - we want to have a patch, as due to the new prefix model the delete operation


### PR DESCRIPTION
Since the prefix list data model has been changed, we can't just delete "a prefix list" anymore, we always have to delete all the entries. This is easy when we know which entries should be in the prefix list. If we want to do a replace, we need to first delete everything that should not be in the list by fetching these entries from the device itself and then add what should be on the device. This is done by our preflight hook.

With the code before this commit we only call the preflight hook if there are still entries left in the list, but now, for existing routers, we want to always call this preflight hook. Therefore we're now removing the explicit call of delete() on empty prefix list.