### PR TITLE
Better dynamic nat pool gateway allocation logic

### DIFF
--- a/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 from collections import OrderedDict
+import copy
 from operator import attrgetter
 import time
 
@@ -23,6 +24,7 @@ from neutron.db import extraroute_db
 from neutron.db import l3_gwmode_db as l3_db
 from neutron.extensions.tagging import TAG_PLUGIN_TYPE
 from neutron.ipam import driver as neutron_ipam_driver
+from neutron.ipam import exceptions as ipam_exc
 from neutron_lib.api.definitions import availability_zone as az_def
 from neutron_lib.api.definitions import l3 as l3_def
 from neutron_lib.callbacks import events
@@ -34,6 +36,7 @@ from neutron_lib.plugins import directory
 from oslo_config import cfg
 from oslo_log import helpers as log_helpers
 from oslo_log import log
+import tenacity
 
 from asr1k_neutron_l3.common import asr1k_constants as constants
 from asr1k_neutron_l3.common import asr1k_exceptions as asr1k_exc
@@ -400,8 +403,14 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
         result = super(ASR1KPluginBase, self).create_router(context, router)
         return result
 
+    @tenacity.retry(retry=tenacity.retry_if_exception_type(ipam_exc.IpAddressAlreadyAllocated),
+                    stop=tenacity.stop_after_attempt(5), reraise=True,
+                    wait=tenacity.wait_random(min=0.0, max=0.05))
     def _update_router_gw_info(self, context, router_id, info,
                                request_body, router=None):
+        # we are modifying the info dict, but need the original in case of a retry --> deepcopy()
+        info = copy.deepcopy(info)
+
         ext_ips = info.get('external_fixed_ips', []) if info else []
         orig_router_atts = self.db.get_router_att(context, router_id)
         dynamic_nat_pool = None
@@ -474,7 +483,6 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
 
             for ext_ip, ip in zip(ext_ips, ips):
                 ext_ip['ip_address'] = ip
-            return dynamic_nat_pool
         else:
             # all ips are specified, check that they are consecutive
             ipset = netaddr.IPSet([ip_def['ip_address'] for ip_def in ext_ips[:-1]])
@@ -492,26 +500,46 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
                     break
             else:
                 raise asr1k_exc.DynamicNatPoolGivenIPsDontBelongToNetwork(ip=pool_from, network_id=info['network_id'])
+
+        # try to allocate a gateway ip that doesn't fragment up the space too much
+        gw_ip_def = ext_ips[-1]
+        if 'subnet_id' in gw_ip_def and 'ip_address' not in gw_ip_def:
+            nat_pool_ips = [netaddr.IPAddress(ext_ip['ip_address']) for ext_ip in ext_ips[:-1]]
+            ip = self._find_gateway_ip_for_dynamic_nat_pool(context, gw_ip_def['subnet_id'], nat_pool_ips)
+            if ip:
+                gw_ip_def['ip_address'] = str(ip)
+            else:
+                LOG.warning("Failed to find gateway ip in subnet %s for router %s with nat pool %s, "
+                            "falling back to letting OpenStack find one (is the IP space exhausted?)",
+                            gw_ip_def['subnet_id'], router_id, dynamic_nat_pool)
+
         return dynamic_nat_pool
+
+    def _get_subnet_allocation_pools_and_allocations(self, context, subnet_id):
+        """Get a subnet's allocation pools and an IPSet of already allocated IPs for a subnet"""
+        ipam_driver = neutron_ipam_driver.Pool.get_instance(None, context)
+        ipam_subnet = ipam_driver.get_subnet(subnet_id)
+        allocation_pools = ipam_subnet.subnet_manager.list_pools(context)
+        allocations = ipam_subnet.subnet_manager.list_allocations(context)
+        ip_allocations = netaddr.IPSet([netaddr.IPAddress(allocation.ip_address) for allocation in allocations])
+
+        return allocation_pools, ip_allocations
 
     def _find_ips_for_dynamic_nat_pool(self, context, subnet_id, ip_count):
         """Search for a block of consecutive IPs in the given subnet, return ips and pool"""
-        ipam_driver = neutron_ipam_driver.Pool.get_instance(None, context)
-        ipam_subnet = ipam_driver.get_subnet(subnet_id)
-        allocations = ipam_subnet.subnet_manager.list_allocations(context)
-        ip_allocations = netaddr.IPSet([netaddr.IPAddress(allocation.ip_address) for allocation in allocations])
+        allocation_pools, ip_allocations = self._get_subnet_allocation_pools_and_allocations(context, subnet_id)
 
         plugin = directory.get_plugin()
         subnet = plugin.get_subnet(context, subnet_id)
 
-        for ip_pool in ipam_subnet.subnet_manager.list_pools(context):
+        for ip_pool in allocation_pools:
             ip_set = netaddr.IPSet()
             ip_set.add(netaddr.IPRange(ip_pool.first_ip, ip_pool.last_ip))
             av_set = ip_set.difference(ip_allocations)
             if av_set.size < ip_count:
                 continue
 
-            av_ranges = sorted(av_set.iter_ipranges(), key=attrgetter('size'))
+            av_ranges = sorted(av_set.iter_ipranges(), key=attrgetter('size', 'first'))
             for av_range in av_ranges:
                 if av_range.size >= ip_count:
                     result = [str(ip) for ip in av_range[:ip_count]]
@@ -519,6 +547,24 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
                     return result, pool
 
         return None, None
+
+    def _find_gateway_ip_for_dynamic_nat_pool(self, context, subnet_id, nat_pool_ips):
+        """Find a usable gateway ip for a nat pool in a subnet without fragmenting the ip space too much"""
+        # current allocation logic: last ip that is not allocated and not in the pool
+        allocation_pools, ip_allocations = self._get_subnet_allocation_pools_and_allocations(context, subnet_id)
+
+        gw_ip_candidate = None
+        for ip_pool in allocation_pools:
+            for ip in netaddr.iter_iprange(ip_pool.last_ip, ip_pool.first_ip, step=-1):
+                # don't need to look at smaller ips if we have a candidate
+                if gw_ip_candidate and ip < gw_ip_candidate:
+                    break
+
+                if ip not in ip_allocations and ip not in nat_pool_ips:
+                    gw_ip_candidate = ip
+                    break
+
+        return gw_ip_candidate
 
     def ensure_default_route_skip_monitoring(self, context, router_id, router):
         tag_plugin = directory.get_plugin(TAG_PLUGIN_TYPE)

--- a/asr1k_neutron_l3/tests/unit/plugins/l3/service_plugins/test_l3_extension_adapter.py
+++ b/asr1k_neutron_l3/tests/unit/plugins/l3/service_plugins/test_l3_extension_adapter.py
@@ -65,12 +65,12 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
                 router_atts = db.get_router_att(ctx, router['router']['id'])
                 self.assertEqual("10.100.1.2-10.100.1.5/24", router_atts.dynamic_nat_pool)
 
-                expected_pool_ips = [f"10.100.1.{n}" for n in range(2, 6)]
+                expected_pool_ips = [f"10.100.1.{n}" for n in range(2, 6)] + ["10.100.1.254"]
                 router_ips = [ip_def['ip_address']
                               for ip_def in router['router']['external_gateway_info']['external_fixed_ips']]
                 router_ips.sort(key=lambda _ip: int(netaddr.IPAddress(_ip)))
                 self.assertEqual(5, len(router_ips))
-                self.assertEqual(expected_pool_ips, router_ips[:-1])
+                self.assertEqual(expected_pool_ips, router_ips)
 
     def test_router_create_with_extended_nat_pool_with_specific_ips(self, pc_mock):
         ctx = context.get_admin_context()
@@ -150,12 +150,12 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
                 router_atts = db.get_router_att(ctx, router['router']['id'])
                 self.assertEqual("10.100.1.6-10.100.1.9/24", router_atts.dynamic_nat_pool)
 
-                expected_pool_ips = [f"10.100.1.{n}" for n in range(6, 10)]
+                expected_pool_ips = [f"10.100.1.{n}" for n in range(6, 10)] + ["10.100.1.254"]
                 router_ips = [ip_def['ip_address']
                               for ip_def in router['router']['external_gateway_info']['external_fixed_ips']]
                 router_ips.sort(key=lambda _ip: int(netaddr.IPAddress(_ip)))
                 self.assertEqual(5, len(router_ips))
-                self.assertEqual(expected_pool_ips, router_ips[:-1])
+                self.assertEqual(expected_pool_ips, router_ips)
 
     def test_router_create_with_extended_nat_pool_non_consecutive_specified_nat_pool(self, pc_mock):
         with self.subnet(cidr="10.100.1.0/24") as s:
@@ -321,7 +321,6 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
                              ]}) as router:
                 db = asr1k_db.get_db_plugin()
                 router_atts = db.get_router_att(ctx, router['router']['id'])
-                router_atts = db.get_router_att(ctx, router['router']['id'])
                 self.assertEqual("10.100.1.2-10.100.1.5/24", router_atts.dynamic_nat_pool)
 
                 with mock.patch.object(ASR1KPluginBase, 'ensure_default_route_skip_monitoring', autospec=True):
@@ -435,3 +434,102 @@ class TestASR1kExtensionAdapter(test_l3.L3BaseForIntTests, test_l3.L3NatTestCase
                              ]}) as router:
                 self.assertEqual("SubnetNotFound",
                                  router["NeutronError"]["type"])
+
+    def test_router_create_with_extended_nat_pool_and_last_ip_used(self, pc_mock):
+        ctx = context.get_admin_context()
+
+        with self.subnet(cidr="10.100.1.0/24") as s:
+            self._set_net_external(s['subnet']['network_id'])
+            self._make_port("json", s['subnet']['network_id'], fixed_ips=[{'ip_address': '10.100.1.254'}])
+            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+                             external_gateway_info={'network_id': s['subnet']['network_id'],
+                                                    'external_fixed_ips': [
+                                                        {'subnet_id': s['subnet']['id']},
+                                                        {'subnet_id': s['subnet']['id']},
+                                                        {'subnet_id': s['subnet']['id']},
+                                                        {'subnet_id': s['subnet']['id']},
+                                                        {'subnet_id': s['subnet']['id']},
+                             ]}) as router:
+                db = asr1k_db.get_db_plugin()
+                router_atts = db.get_router_att(ctx, router['router']['id'])
+                self.assertEqual("10.100.1.2-10.100.1.5/24", router_atts.dynamic_nat_pool)
+
+                expected_pool_ips = [f"10.100.1.{n}" for n in range(2, 6)] + ["10.100.1.253"]
+                router_ips = [ip_def['ip_address']
+                              for ip_def in router['router']['external_gateway_info']['external_fixed_ips']]
+                router_ips.sort(key=lambda _ip: int(netaddr.IPAddress(_ip)))
+                self.assertEqual(5, len(router_ips))
+                self.assertEqual(expected_pool_ips, router_ips)
+
+    def test_router_create_with_extended_nat_pool_and_selected_pool_is_at_end(self, pc_mock):
+        ctx = context.get_admin_context()
+
+        with self.subnet(cidr="10.100.1.0/24") as s:
+            self._set_net_external(s['subnet']['network_id'])
+            self._make_port("json", s['subnet']['network_id'], fixed_ips=[{'ip_address': '10.100.1.250'}])
+            with self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+                             external_gateway_info={'network_id': s['subnet']['network_id'],
+                                                    'external_fixed_ips': [
+                                                        {'subnet_id': s['subnet']['id']},
+                                                        {'subnet_id': s['subnet']['id']},
+                                                        {'subnet_id': s['subnet']['id']},
+                                                        {'subnet_id': s['subnet']['id']},
+                                                        {'subnet_id': s['subnet']['id']},
+                             ]}) as router:
+                db = asr1k_db.get_db_plugin()
+                router_atts = db.get_router_att(ctx, router['router']['id'])
+                self.assertEqual("10.100.1.251-10.100.1.254/24", router_atts.dynamic_nat_pool)
+
+                expected_pool_ips = ["10.100.1.249"] + [f"10.100.1.{n}" for n in range(251, 255)]
+                router_ips = [ip_def['ip_address']
+                              for ip_def in router['router']['external_gateway_info']['external_fixed_ips']]
+                router_ips.sort(key=lambda _ip: int(netaddr.IPAddress(_ip)))
+                self.assertEqual(5, len(router_ips))
+                self.assertEqual(expected_pool_ips, router_ips)
+
+    def test_router_create_with_extended_nat_pool_where_gw_ip_is_snatched_before_allocation(self, pc_mock):
+        ctx = context.get_admin_context()
+
+        with self.subnet(cidr="10.100.1.0/24") as s:
+            self._set_net_external(s['subnet']['network_id'])
+
+            # machinery to allocate the ip on first try
+            l3_plugin = directory.get_plugin(plugin_constants.L3)
+            is_first_try = True
+            orig_meth = l3_plugin._find_gateway_ip_for_dynamic_nat_pool
+
+            def alloc_last_ip_on_first_try(*args, **kwargs):
+                nonlocal is_first_try
+
+                ret = orig_meth(*args, **kwargs)
+                if is_first_try:
+                    self.assertEqual("10.100.1.254", str(ret))
+
+                    # allocate the ip painstakingly found by the allocation algorithm *mwahahahaha*
+                    self._make_port("json", s['subnet']['network_id'], fixed_ips=[{'ip_address': '10.100.1.254'}])
+                    is_first_try = False
+                else:
+                    self.assertEqual("10.100.1.253", str(ret))
+                return ret
+
+            with mock.patch.object(l3_plugin, '_find_gateway_ip_for_dynamic_nat_pool',
+                                   side_effect=alloc_last_ip_on_first_try), \
+                    self.router(name="r1", admin_state_up=True, tenant_id=uuidutils.generate_uuid(),
+                                external_gateway_info={'network_id': s['subnet']['network_id'],
+                                                       'external_fixed_ips': [
+                                                           {'subnet_id': s['subnet']['id']},
+                                                           {'subnet_id': s['subnet']['id']},
+                                                           {'subnet_id': s['subnet']['id']},
+                                                           {'subnet_id': s['subnet']['id']},
+                                                           {'subnet_id': s['subnet']['id']},
+                                ]}) as router:
+                db = asr1k_db.get_db_plugin()
+                router_atts = db.get_router_att(ctx, router['router']['id'])
+                self.assertEqual("10.100.1.2-10.100.1.5/24", router_atts.dynamic_nat_pool)
+
+                expected_pool_ips = [f"10.100.1.{n}" for n in range(2, 6)] + ["10.100.1.253"]
+                router_ips = [ip_def['ip_address']
+                              for ip_def in router['router']['external_gateway_info']['external_fixed_ips']]
+                router_ips.sort(key=lambda _ip: int(netaddr.IPAddress(_ip)))
+                self.assertEqual(5, len(router_ips))
+                self.assertEqual(expected_pool_ips, router_ips)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ xmltodict >= 0.11.0
 dictdiffer >=0.7.0
 osc-lib>=1.8.0 # Apache-2.0
 retrying >=1.3.3
+tenacity>=6.0.0 # Apache-2.0
 prometheus_client>=0.0.19
 bs4>=0.0.1
 ncclient


### PR DESCRIPTION
For dynamic NAT pooling we always have one block of consecutive IPv4
addresses and one gateway address, which does not need to be part of the
block. If the gateway IP is not specified by the user we left it to
Neutron to allocate a fitting IP, which randomly allocates one. This
caused problems for users as this random IP might fragment up the IP
space of their network, resulting in less routers with NAT pools fitting
in the network.

To fix this we now use a more deterministic approach: We allocate the
highest available IP in the network. As we always try to use the
smallest block with the lowest starting IP for the NAT pool we should
end up having less fragmentations in the IP space. Other methods we
thought of were using first available after pool or first available
around pool but this might interfere with other pool allocations in case
we have many routers entering and leaving the network (it also might
not, I don't have any reliable data on this - the decision is based on
educated guesses).

We also now retry the allocation in the rare case that in between
selecting and allocating the IP someone else allocated it, with up to 5
tries and a random wait between 0 and 0.05s. The retry is only done when
an IpAddressAlreadyAllocated exception occurs. This might also lead to a
retry if the user specifies already allocated options, leading to a few
more DB queries and a slower query of 0.2s.

For retrying we use tenacity, which is also used by neutron. The asr1k
driver already uses retrying, but this library is no longer maintained
and we should switch to tenacity for everything else in the foreseeable
future.

The allocation logic for the NAT pool itself now also changes slightly,
in that we make sure that we sort all available IP address space chunks
not only by size, but also by their first IP. So in cases where we have
multiple chunks of the same size we should end up with the chunk with
the smallest starting IP.