### PR TITLE
Properly format "extra atts missing" log message

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -420,8 +420,8 @@ class Router(Base):
             if self.extra_atts is not None:
                 return self.extra_atts.get(port.get('id'), {})
             else:
-                LOG.error("Cannot get  extra atts from {} for port {} on router {}"
-                          "".format(self.extra_atts, port.get('id'), self.router_id))
+                LOG.error("Cannot get extra atts from %s for port %s on router %s",
+                          self.extra_atts, port.get('id'), self.router_id)
                 return {}
         except BaseException as e:
 


### PR DESCRIPTION
When extra atts are missing we get a sentry error. As the log message is formatted with format() it is not properly aggregated, so it is quite spammy. By letting logging do the formatting we should have better aggregation. We're also removing the extra whitespace while we're on it.