### PR TITLE
Delete prefix list if there's nothing to update

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/prefix.py
+++ b/asr1k_neutron_l3/models/neutron/l3/prefix.py
@@ -40,6 +40,12 @@ class BasePrefix(base.Base):
     def diff(self, should_be_none=False):
         return super().diff(should_be_none=not self.prefixes)
 
+    def update(self):
+        if self.prefixes:
+            return super().update()
+        else:
+            return self.delete()
+
     def _make_seq(self, no, cidr, action="permit"):
         return prefix.PrefixSeq(no=no, action=action, ip=cidr)
 


### PR DESCRIPTION
When we have a router with a prefix list that does not contain any prefixes, calling diff does not show a diff (as we have set should_be_none=True in this case), but an update still detects a diff and thus sends out an update call + logs the following "diff":

Internal validate of PrefixV4 for $agent_ip produced 1 diff(s) [{'entity': 'snat-$vrf_id', 'type': 'remove', 'item': '', 'neutron': ('prefix-lists', {'prefixes': []}), 'device': None}]

This is, because update() does not allow us to pass the should_be_none attribute. Now we have two options: add should_be_none to all update() methods or do it the same way as we do with the other cases, e.g. the RouteMap class: On update, if we shouldn't have this on the device, we call delete(). In this case we went for the latter, as this is consistent with the current codebase. This is then checked with an _internal_exists() call, which doesn't find the prefix list on the device and therefore does nothing. Less logs and maybe even less update calls.