### PR TITLE
Add garp feature flag, disable it by default

### DIFF
--- a/asr1k_neutron_l3/common/config.py
+++ b/asr1k_neutron_l3/common/config.py
@@ -95,6 +95,8 @@ ASR1K_L3_OPTS = [
                 help=('Advertise BGP routes (BGPVPN/DAPNets) on IPv4 via redistribute static/connected + route-map '
                       'instead of using network statements. This avoids the global config lock, that occurs on current '
                       'firmwares (at least 17.15) when the BGP tree is modified.')),
+    cfg.BoolOpt('enable_garp', default=False,
+                help=_("Enable GARP feature for floating IPs (requires firmware >= 17.13)")),
 ]
 
 ASR1K_L2_OPTS = [

--- a/asr1k_neutron_l3/models/netconf_yang/nat.py
+++ b/asr1k_neutron_l3/models/netconf_yang/nat.py
@@ -774,8 +774,6 @@ class StaticNat(NyBase):
         if context.version_min_17_13:
             if self.garp_bdvif_iface:
                 entry[NATConstants.GARP_IFACE] = {NATConstants.BDVIF: str(self.garp_bdvif_iface)}
-            else:
-                entry[NATConstants.GARP_IFACE] = {xml_utils.OPERATION: NC_OPERATION.REMOVE}
 
         return entry
 

--- a/asr1k_neutron_l3/models/neutron/l3/nat.py
+++ b/asr1k_neutron_l3/models/neutron/l3/nat.py
@@ -158,7 +158,9 @@ class FloatingIp(BaseNAT):
         self.garp_iface_id = None
         if self.gateway_interface:
             self.mac_address = self.gateway_interface.mac_address
-            self.garp_iface_id = self.gateway_interface.bridge_domain
+            if cfg.CONF.asr1k_l3.enable_garp:
+                self.garp_iface_id = self.gateway_interface.bridge_domain
+
         self._rest_definition = l3_nat.StaticNat(vrf=self.router_id, local_ip=self.local_ip, global_ip=self.global_ip,
                                                  bridge_domain=self.bridge_domain,
                                                  redundancy=self.redundancy, mapping_id=self.mapping_id,

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_serialization.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_serialization.py
@@ -72,7 +72,7 @@ class SerializationTest(base.BaseTestCase):
         sn = StaticNat(**sn_args)
 
         context_17_13 = FakeASR1KContext()
-        self.assertEqual({'@operation': 'remove'}, sn.to_single_dict(context_17_13).get('garp-interface'))
+        self.assertNotIn('garp-interface', sn.to_single_dict(context_17_13))
 
     def test_bdvif_ipv6(self):
         ipv6_addresses = ["fd00::/64", "fd00::256/64"]


### PR DESCRIPTION
The garp feature is not yet compatible with the no-alias feature. To proceed with the first rollout of 17.15 we're now introducing a feature switch for garp and leave it off by default. Once we're ready for deploying garp everywhere we'll either change the default, add a version detection flag or configure it on a per-agent basis (but it's most likely going to be autodetection).

We are also removing the garp flag else-case which originally should have removed the garp flag from config.  As StaticNatList is already called with operation="replace" we don't have to do an explicit removal (and if we would use operation="remove" for the garp flag we would in fact get an error saying "The operation remove is not allowed under replace").