### PR TITLE
Fix: Unprocessed ports deleted from `updated_ports` and `deleted_ports`

### DIFF
--- a/asr1k_neutron_l3/plugins/ml2/agents/asr1k_ml2_agent.py
+++ b/asr1k_neutron_l3/plugins/ml2/agents/asr1k_ml2_agent.py
@@ -259,7 +259,8 @@ class ASR1KNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
                                                                         self.conf.host)
 
                 bridgedomain.update_ports(router_ports, callback=self._bound_ports)
-                self.updated_ports = {}
+                for port_id in ports_to_bind:
+                    self.updated_ports.pop(port_id, None)
             except BaseException as err:
                 LOG.exception(err)
 
@@ -271,7 +272,8 @@ class ASR1KNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
                 extra_atts = self.agent_rpc.get_extra_atts(self.context, ports_to_delete, agent_id=self.agent_id,
                                                            host=self.conf.host)
                 bridgedomain.delete_ports(extra_atts, callback=self._deleted_ports)
-                self.deleted_ports = {}
+                for port_id in ports_to_delete:
+                    self.deleted_ports.pop(port_id, None)
             except BaseException as err:
                 LOG.exception(err)
 


### PR DESCRIPTION
When a port update or creation comes in, the ml2 agent's `port_update`
method puts it into self.updated_ports.

From there the port_id is picked up by `process_ports` which gets a copy
of the dictionary, finds out which ports actually belong to this agent
and then runs netconf to configure them. At the end of its operation it
clears the global `self.updated_port`.

Ports that arrived while this was happening would be cleared alltogether
and hence have to wait until the next network syncloop picks them up.

Let us only delete the ports from the dictionary that we have actually
had in our copy.

The same problem also applies for the `deleted_ports`.