### PR TITLE
Deduplicate ACEs before creating rest definition

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/access_list.py
+++ b/asr1k_neutron_l3/models/neutron/l3/access_list.py
@@ -27,7 +27,14 @@ class AccessList(base.Base):
     @property
     def _rest_definition(self):
         acl = access_list.AccessList(name=self.id)
-        for i, rule in enumerate(self.rules):
+        rule_set = set()
+        dedup_rules = []
+        for rule in self.rules:
+            if rule in rule_set:
+                continue
+            dedup_rules.append(rule)
+            rule_set.add(rule)
+        for i, rule in enumerate(dedup_rules):
             sequence = (i + 1) * 10
             ace_rule = access_list.ACERule(
                 access_list=self.id,
@@ -62,12 +69,30 @@ class Rule():
         self.protocol = protocol
         self.source = source
         self.source_mask = source_mask
-        self.source_port_range = source_port_range
+        # Make port range a tuple for easier hashing and equality checks
+        self.source_port_range = tuple(source_port_range) if source_port_range else None
         self.destination = destination
         self.destination_mask = destination_mask
-        self.destination_port_range = destination_port_range
+        # Make port range a tuple for easier hashing and equality checks
+        self.destination_port_range = tuple(destination_port_range) if destination_port_range else None
         self.named_message_type = named_message_type
         self.established = established
+
+    def _get_tuple(self):
+        """Return tuple of all fields used for hashing and equality."""
+        return (self.action, self.protocol,
+                self.source, self.source_mask, self.source_port_range,
+                self.destination, self.destination_mask,
+                self.destination_port_range,
+                self.named_message_type, self.established)
+
+    def __hash__(self):
+        return hash(self._get_tuple())
+
+    def __eq__(self, value):
+        if not isinstance(value, Rule):
+            return False
+        return self._get_tuple() == value._get_tuple()
 
     @property
     def ip_args(self):

--- a/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_access_list.py
+++ b/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_access_list.py
@@ -1,0 +1,53 @@
+# Copyright 2026 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from asr1k_neutron_l3.models.neutron.l3.access_list import AccessList, Rule
+from asr1k_neutron_l3.tests.common.fixtures import RouterWithSyncDataTestCase
+
+
+class TestAccessList(RouterWithSyncDataTestCase):
+
+    def test_access_list_rule_deduplication(self):
+        acl = AccessList(id='test-acl')
+
+        # create two identical rules (must be two rules, so they are different instances, for eq check)
+        rule1 = Rule(action='permit',
+                     protocol='tcp',
+                     source='10.0.0.1',
+                     destination='10.0.0.2',
+                     destination_port_range=("443",))
+        rule2 = Rule(action='permit',
+                     protocol='tcp',
+                     source='10.0.0.1',
+                     destination='10.0.0.2',
+                     destination_port_range=("443",))
+
+        rule3 = Rule(action='permit',
+                     protocol='tcp',
+                     source='10.0.0.6',
+                     destination='10.0.0.7',
+                     destination_port_range=["443"])
+
+        rule4 = Rule(action='permit',
+                     protocol='tcp',
+                     source='10.0.0.6',
+                     destination='10.0.0.7',
+                     destination_port_range=["443"])
+
+        acl.append_rule(rule1)
+        acl.append_rule(rule2)
+        acl.append_rule(rule3)
+        acl.append_rule(rule4)
+
+        self.assertEqual(2, len(acl._rest_definition.rules))


### PR DESCRIPTION
Openstack happily accepts duplicate entries, the device however doesn't.
We will continue to allow users to create duplicate entries, yet chose
to dedeuplicate them before pushing to the device.
