### PR TITLE
Support classful networking in BGP YANG API

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/bgp.py
+++ b/asr1k_neutron_l3/models/netconf_yang/bgp.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 from collections import OrderedDict
+import ipaddress
 
 from asr1k_neutron_l3.common.utils import from_cidr, to_cidr
 from asr1k_neutron_l3.models.netconf_yang.ny_base import NyBase, execute_on_pair, NC_OPERATION
@@ -43,6 +44,7 @@ class BGPConstants(object):
     UNICAST = "unicast"
     NETWORK = "network"
     WITH_MASK = "with-mask"
+    NO_MASK = "no-mask"
     NUMBER = "number"
     MASK = "mask"
     ROUTE_MAP = "route-map"
@@ -181,6 +183,8 @@ class AddressFamilyV4(AddressFamilyBase):
             {'key': 'vrf', 'yang-key': 'name'},
             {'key': 'networks', 'yang-path': 'ipv4-unicast/network', 'yang-key': BGPConstants.WITH_MASK,
              'type': [NetworkV4], 'default': []},
+            {'key': 'networks_no_mask', 'yang-path': 'ipv4-unicast/network', 'yang-key': BGPConstants.NO_MASK,
+             'type': [NetworkV4NoMask], 'default': []},
             {'key': 'redistribute_connected_with_rm', 'yang-key': 'route-map',
              'yang-path': 'ipv4-unicast/redistribute-vrf/connected'},
             {'key': 'redistribute_static_with_rm', 'yang-key': 'route-map',
@@ -195,7 +199,8 @@ class AddressFamilyV4(AddressFamilyBase):
             xml_utils.OPERATION: NC_OPERATION.PUT,
             BGPConstants.NETWORK: {
                 BGPConstants.WITH_MASK: [
-                    net.to_dict(context) for net in sorted(self.networks, key=lambda x: (x.number, x.mask))
+                    net.to_dict(context) for net in sorted(self.networks + self.networks_no_mask,
+                                                           key=lambda x: (x.number, x.mask))
                 ],
             },
         }
@@ -308,6 +313,30 @@ class NetworkV4(NyBase):
         if self.route_map:
             net[BGPConstants.ROUTE_MAP] = self.route_map
         return net
+
+
+class NetworkV4NoMask(NetworkV4):
+    CLASSFUL_NETWORKS = (
+        (ipaddress.IPv4Network("0.0.0.0/1"), "255.0.0.0"),
+        (ipaddress.IPv4Network("128.0.0.0/2"), "255.255.0.0"),
+        (ipaddress.IPv4Network("192.0.0.0/3"), "255.255.255.0"),
+
+        # class D and E are summarized to /3 as both classes get the same netmask
+        # IOS XE 17.15 cli uses 255.255.255.255 as netmask for both
+        (ipaddress.IPv4Network("224.0.0.0/3"), "255.255.255.255"),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not self.mask:
+            ip = ipaddress.IPv4Address(self.number)
+            for class_cidr, default_netmask in self.CLASSFUL_NETWORKS:
+                if ip in class_cidr:
+                    self.mask = default_netmask
+                    break
+            else:
+                self.mask = "255.255.255.255"
 
 
 class NetworkV6(NyBase):

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_parsing.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_parsing.py
@@ -307,6 +307,81 @@ class ParsingTest(base.BaseTestCase):
         self.assertEqual("test123", bgp_af6_dict['vrf']['ipv6-unicast']['redistribute-v6']['connected']['route-map'])
         self.assertEqual("test456", bgp_af6_dict['vrf']['ipv6-unicast']['redistribute-v6']['static']['route-map'])
 
+    def test_bgp_parsing_without_netmask(self):
+        bgp_xml = """
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <data>
+    <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+      <router>
+        <bgp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-bgp">
+          <id>65123</id>
+          <address-family>
+            <with-vrf>
+              <ipv4>
+                <af-name>unicast</af-name>
+                <vrf>
+                  <name>1ccc4863d8bc4c82affa0cb198e8d5d1</name>
+                  <ipv4-unicast>
+                    <network>
+                      <with-mask>
+                        <number>0.0.0.0</number>
+                        <mask>128.0.0.0</mask>
+                      </with-mask>
+                      <with-mask>
+                        <number>10.180.7.0</number>
+                        <mask>255.255.255.0</mask>
+                      </with-mask>
+                      <with-mask>
+                        <number>10.192.23.128</number>
+                        <mask>255.255.255.128</mask>
+                        <route-map>RM-DAP-EXTRA-ROUTES</route-map>
+                      </with-mask>
+                      <with-mask>
+                        <number>172.16.0.0</number>
+                        <mask>255.240.0.0</mask>
+                      </with-mask>
+                      <no-mask>
+                        <number>10.0.0.0</number>
+                      </no-mask>
+                      <no-mask>
+                        <number>147.204.0.0</number>
+                      </no-mask>
+                      <no-mask>
+                        <number>192.168.23.0</number>
+                        <route-map>meow</route-map>
+                      </no-mask>
+                    </network>
+                  </ipv4-unicast>
+                </vrf>
+              </ipv4>
+            </with-vrf>
+          </address-family>
+        </bgp>
+      </router>
+    </native>
+  </data>
+</rpc-reply>
+"""
+
+        expected_networks = (
+            ("0.0.0.0", "128.0.0.0", None),
+            ("10.180.7.0", "255.255.255.0", None),
+            ("10.192.23.128", "255.255.255.128", "RM-DAP-EXTRA-ROUTES"),
+            ("172.16.0.0", "255.240.0.0", None),
+            ("10.0.0.0", "255.0.0.0", None),
+            ("147.204.0.0", "255.255.0.0", None),
+            ("192.168.23.0", "255.255.255.0", "meow"),
+        )
+
+        context = FakeASR1KContext()
+        bgp_af = bgp.AddressFamilyV4.from_xml(bgp_xml, context)
+        parsed_nets = [
+            (n['number'], n['mask'], n.get('route-map'))
+            for n in bgp_af.to_dict(context)['vrf']['ipv4-unicast']['network']['with-mask']
+        ]
+        self.assertEqual(sorted(expected_networks),
+                         sorted(parsed_nets))
+
     def test_static_nat_parsing(self):
         xml = """
 <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"


### PR DESCRIPTION
Before Classless Inter Domain Routing was introduced in 1993 (RFC1518), everything was split up in classes. From just looking at an IP address, you would know the class, as each part had its own set-in-stone netmask. For the Cisco CLI config, this meant that advertising a network via a bgp network statement didn't need a netmask. Later, when CIDR became popular, most likely a mask was attached to the network command, allowing to also advertise differently-subnetted prefixes. The old "network 10.0.0.0", which would then mean "advertise 10.0.0.0/8", was (and is) still valid. Commands specifying a mask, which could otherwise be abbreviated with omitting the mask (due to their "classfull nature") get autoconverted, meaning typing "network 10.0.0.0 mask 255.0.0.0.0" on the cli will result to "network 10.0.0.0" in the config. This conversion is done for everything that directly fits into one of the classes.

Netconf YANG is an abstraction that converts xml config statements to cli config and the other way around (with confd / config db inbetween, but that's not important here). Now, when we configure a network to be announced via BGP and specify a mask, YANG generates cli config for said network, which then ends up in the config and gets converted to a classfull statement (without netmask). When syncing the config the other way around, i.e. back into confd/YANG, the statements with and without mask are separate config blocks:

```
<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
  <router>
    <bgp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-bgp">
      <id>...</id>
      <address-family>
        <with-vrf>
            <vrf>
              <name>...</name>
              <ipv4-unicast>
                <network>
                  <with-mask>
                    <number>172.16.0.0</number>
                    <mask>255.240.0.0</mask>
                  </with-mask>
                  <no-mask>
                    <number>10.0.0.0</number>
                  </no-mask>
                </network>
              </ipv4-unicast>
            </vrf>
          </ipv4>
        </with-vrf>
      </address-family>
    </bgp>
  </router>
</native>
```

For the driver this means that it configures something, this gets automatically converted and then, when looking for its config, it looks like there are prefixes missing - we get a router diff for something that is more or less correctly configured on the device. So, to handle this case, we now need to teach our driver how to properly read classfull networks. We do this, by subclassing our NetworkV4 class and use it for the <no-mask> tag. After parsing the xml block, it will then iterate through the classfull netblocks, see to which our prefix belongs and use the respective netmask. For class D and E we summarize both networks into one 224.0.0.0/3. The Cisco cli abbreviates both subnets when using 255.255.255.255 as netmask, so that is what we're using as netmask for these as well when we're reconstructing it.

With that being said: Our driver now officially supports classful networking.