### PR TITLE
Fix IPv6 Tunnel interface handling

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
@@ -155,7 +155,8 @@ class BDInterface(NyBase):
             {'key': 'ip_address', 'yang-path': 'ip/address', 'yang-key': "primary", 'type': BDPrimaryIpAddress},
             {'key': 'secondary_ip_addresses', 'yang-path': 'ip/address', 'yang-key': "secondary",
              'type': [BDSecondaryIpAddress], 'default': [], 'validate': False},
-            {'key': 'ipv6_addresses', 'yang-path': 'ipv6/address', 'yang-key': "prefix-list", 'type': [BDIpv6Address]},
+            {'key': 'ipv6_addresses', 'yang-path': 'ipv6/address', 'yang-key': "prefix-list",
+             'type': [IfaceIpv6Address]},
             {'key': 'nat_inside', 'yang-key': 'inside', 'yang-path': 'ip/nat', 'default': False,
              'yang-type': YANG_TYPE.EMPTY},
             {'key': 'nat_outside', 'yang-key': 'outside', 'yang-path': 'ip/nat', 'default': False,
@@ -490,7 +491,7 @@ class BDPrimaryIpAddress(NyBase):
         return ip
 
 
-class BDIpv6Address(NyBase):
+class IfaceIpv6Address(NyBase):
     ITEM_KEY = L3Constants.PREFIX
     LIST_KEY = L3Constants.PREFIX_LIST
 
@@ -571,7 +572,8 @@ class TunnelInterface(NyBase):
 
             {'key': 'ipv4_address', 'yang-key': 'address', 'yang-path': 'ip/address/primary'},
             {'key': 'ipv4_netmask', 'yang-key': 'mask', 'yang-path': 'ip/address/primary'},
-            {'key': 'ipv6_prefix', 'yang-key': 'prefix', 'yang-path': 'ipv6/address/prefix-list'},
+            {'key': 'ipv6_addresses', 'yang-path': 'ipv6/address', 'yang-key': "prefix-list",
+             'type': [IfaceIpv6Address]},
 
             {'key': 'tunnel_src', 'yang-key': 'source', 'yang-path': 'tunnel'},
             {'key': 'tunnel_dest_ipv4', 'yang-key': 'ipv4', 'yang-path': 'tunnel/destination-config'},
@@ -628,8 +630,13 @@ class TunnelInterface(NyBase):
             iface[L3Constants.IP] = ip
 
         ipv6 = {}
-        if self.ipv6_prefix:
-            ipv6[L3Constants.ADDRESS] = {L3Constants.PREFIX_LIST: {L3Constants.PREFIX: self.ipv6_prefix}}
+        if self.ipv6_addresses:
+            ipv6[L3Constants.ADDRESS] = {
+                xml_utils.OPERATION: NC_OPERATION.PUT,
+                L3Constants.PREFIX_LIST: [
+                    addr.to_dict(context) for addr in self.ipv6_addresses
+                ]
+            }
         if self.ipv6_tcp_mss:
             ipv6[L3Constants.TCP] = {L3Constants.ADJUST_MSS: self.ipv6_tcp_mss}
         if self.ipv6_mtu:

--- a/asr1k_neutron_l3/models/neutron/l3/interface.py
+++ b/asr1k_neutron_l3/models/neutron/l3/interface.py
@@ -21,7 +21,7 @@ from asr1k_neutron_l3.common import utils
 from asr1k_neutron_l3.models.neutron.l3 import base
 from asr1k_neutron_l3.models.neutron.l3.firewall import Zone
 from asr1k_neutron_l3.models.netconf_yang.l3_interface import BDInterface, BDPrimaryIpAddress, BDSecondaryIpAddress, \
-    BDIpv6Address, TrafficFilter
+    IfaceIpv6Address, TrafficFilter
 from asr1k_neutron_l3.models.netconf_yang.l3_interface_state import BDInterfaceState
 
 LOG = logging.getLogger(__name__)
@@ -152,7 +152,7 @@ class Interface(base.Base):
         for n_fixed_ip in self.router_port.get('fixed_ips', []):
             if utils.get_ip_version(n_fixed_ip['ip_address']) == 6:
                 self._primary_v6_subnet_id = n_fixed_ip.get('subnet_id')
-                ipv6_addrs.append(BDIpv6Address(prefix=f"{n_fixed_ip['ip_address']}/{n_fixed_ip['prefixlen']}"))
+                ipv6_addrs.append(IfaceIpv6Address(prefix=f"{n_fixed_ip['ip_address']}/{n_fixed_ip['prefixlen']}"))
         return ipv6_addrs
 
     def _set_gateway_ips(self):

--- a/asr1k_neutron_l3/models/neutron/l3/vpn.py
+++ b/asr1k_neutron_l3/models/neutron/l3/vpn.py
@@ -265,7 +265,7 @@ class TunnelInterface(base.Base):
 
             ipv4_address=str(local_cidr_v4.ip),
             ipv4_netmask=str(local_cidr_v4.netmask),
-            ipv6_prefix=str(local_cidr_v6),
+            ipv6_addresses=[l3_interface.IfaceIpv6Address(prefix=str(local_cidr_v6))],
             path_mtu_discovery=True,
 
             ipsec_profile=uuid_to_ipsec_short_id(sitecon['id']),

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_l3_interface.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_l3_interface.py
@@ -48,6 +48,13 @@ class TestL3Interface(base.BaseTestCase):
             </tcp>
             <mtu>8950</mtu>
           </ip>
+          <ipv6>
+            <address>
+              <prefix-list>
+                <prefix>FD86:CB3C:C988:28C:C2B:597A:B88C:AC85/126</prefix>
+              </prefix-list>
+            </address>
+          </ipv6>
           <tunnel xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-tunnel">
             <source>4.5.6.7</source>
             <destination-config>
@@ -95,6 +102,10 @@ class TestL3Interface(base.BaseTestCase):
         self.assertEqual("8950", iface.mtu)
         self.assertEqual("169.254.169.254", iface.ipv4_address)
         self.assertEqual("255.255.255.252", iface.ipv4_netmask)
+        self.assertEqual(1, len(iface.ipv6_addresses))
+        self.assertEqual("fd86:cb3c:c988:28c:c2b:597a:b88c:ac85/126", iface.ipv6_addresses[0].prefix.lower())
+        self.assertEqual("fd86:cb3c:c988:28c:c2b:597a:b88c:ac85/126",
+                         iface.to_dict(context)['Tunnel']['ipv6']['address']['prefix-list'][0]['prefix'])
         self.assertEqual("4.5.6.7", iface.tunnel_src)
         self.assertEqual("3.141.59.26", iface.tunnel_dest_ipv4)
         self.assertTrue(iface.tunnel_mode_ipsec_ipv4)

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_serialization.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_serialization.py
@@ -17,7 +17,7 @@ import xmltodict
 from neutron.tests import base
 
 from asr1k_neutron_l3.models.asr1k_pair import FakeASR1KContext
-from asr1k_neutron_l3.models.netconf_yang.l3_interface import BDInterface, BDIpv6Address
+from asr1k_neutron_l3.models.netconf_yang.l3_interface import BDInterface, IfaceIpv6Address
 from asr1k_neutron_l3.models.netconf_yang.nat import NATConstants, StaticNat
 
 
@@ -77,7 +77,7 @@ class SerializationTest(base.BaseTestCase):
     def test_bdvif_ipv6(self):
         ipv6_addresses = ["fd00::/64", "fd00::256/64"]
         bdvif = {
-            'ipv6_addresses': [BDIpv6Address(prefix=ip) for ip in ipv6_addresses]
+            'ipv6_addresses': [IfaceIpv6Address(prefix=ip) for ip in ipv6_addresses]
         }
         iface = BDInterface(**bdvif)
         context = FakeASR1KContext()


### PR DESCRIPTION
We now normalize IPv6 addresses coming from the device to lowercase and also handle multiple v6 addresses.