### PR TITLE
Disable nat outside on gw interface for VPNaaS

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/interface.py
+++ b/asr1k_neutron_l3/models/neutron/l3/interface.py
@@ -185,8 +185,9 @@ class Interface(base.Base):
 
 class GatewayInterface(Interface):
 
-    def __init__(self, router_id, router_port, extra_atts, dynamic_nat_pool):
+    def __init__(self, router_id, router_port, extra_atts, dynamic_nat_pool, nat_outside=True):
         self.dynamic_nat_pool = dynamic_nat_pool
+        self.nat_outside = nat_outside
         super().__init__(router_id, router_port, extra_atts)
 
         # annotate details about the router to the interface description so this can be picked up by SNMP
@@ -199,7 +200,7 @@ class GatewayInterface(Interface):
         interface_args = dict(name=self.bridge_domain, description=description,
                               mac_address=self.mac_address, mtu=self.mtu, vrf=self.vrf,
                               ip_address=self.ipv4_address, ipv6_addresses=self.ipv6_addresses,
-                              secondary_ip_addresses=self.secondary_ip_addresses, nat_outside=True,
+                              secondary_ip_addresses=self.secondary_ip_addresses, nat_outside=self.nat_outside,
                               redundancy_group=None, route_map='EXT-TOS', access_group_out='EXT-TOS',
                               ntp_disable=True, arp_timeout=cfg.CONF.asr1k_l3.external_iface_arp_timeout)
 

--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -134,6 +134,11 @@ class Router(Base):
         return any(iface.ipv6_addresses for iface in self.interfaces.all_interfaces) or \
                 bool(self.router_info.get('vpn'))
 
+    @property
+    def is_vpnaas_only(self):
+        """Router has VPNs and no internal subnets"""
+        return bool(self.router_info.get('vpn') and not self.router_info.get('_interfaces'))
+
     def _get_fwaas_acls_by_port(self):
         """
         This method retrieves the ACLs associated with each port for the router.
@@ -164,13 +169,14 @@ class Router(Base):
 
         gw_port = self.router_info.get('gw_port')
         if gw_port is not None:
+            # don't enable nat on gw interface if we have VPNs and no internal subnets
             self.gateway_interface = l3_interface.GatewayInterface(self.router_id, gw_port,
                                                                    self._port_extra_atts(gw_port),
-                                                                   self.router_atts.get('dynamic_nat_pool'))
+                                                                   self.router_atts.get('dynamic_nat_pool'),
+                                                                   nat_outside=not self.is_vpnaas_only)
             interfaces.append(self.gateway_interface)
 
         inf_ports = self.router_info.get('_interfaces', [])
-
         fwaas_acls = self._get_fwaas_acls_by_port()
         for inf_port in inf_ports or []:
             interfaces.append(

--- a/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_router.py
+++ b/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_router.py
@@ -41,6 +41,7 @@ class TestRouterClass(RouterWithSyncDataTestCase):
         self.assertFalse(dev_router.bgp_address_family[6].enable_bgp)
         self.assertIsNotNone(dev_router.vrf._rest_definition.address_family_ipv4)
         self.assertIsNone(dev_router.vrf._rest_definition.address_family_ipv6)
+        self.assertTrue(dev_router.gateway_interface._rest_definition.nat_outside)
 
     def test_router_with_dapnet_v4(self):
         with self.address_scope(name="the-open-sea") as addr_scope, \
@@ -152,6 +153,7 @@ class TestRouterClassWithVPN(RouterWithSyncDataTestCase):
         self.assertFalse(iface.shutdown)
         ike_keyring = self._find_entry("IKEv2Keyring", dev_router.vpnaas_conf)._rest_definition
         self.assertEqual("supercilium", ike_keyring.peers[0].psk)
+        self.assertFalse(dev_router.gateway_interface._rest_definition.nat_outside)
 
     def test_router_with_vpn_transport_conf(self):
         router = self._make_vpn_ready_router()


### PR DESCRIPTION
For VPNaaS routers we don't want to have "ip nat outside" on the gateway interface, as this will cause outgoing connections to get natted, which will break bidirectional connectivity. As we don't need NAT on our VPNaaS routers anyway we just remove the statement.

Detection of "this is a VPNaaS" router is done in the agent by checking if a) we have VPNs on the router and b) that there are no internal subnets attached. With the current feature set we don't allow internal subnets on an VPNaaS router, but just in case I would rather want to break the VPN instead of having unnatted traffic from an internal subnet. If a router accidentally gets a VPN that shouldn't have one then I'd opt for the internal subnet instead of the VPN (and this would need fixing anyway).

This change might result in clients being able to spoof traffic by sending traffic to the router via the VPN tunnel that then egresses the router via the default route with a source ip controlled by the user. We will take care of this in a followup commit.