### PR TITLE
Spoofing protection for VPNaaS router

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/access_list.py
+++ b/asr1k_neutron_l3/models/netconf_yang/access_list.py
@@ -82,6 +82,11 @@ class AccessList(NyBase):
     LIST_KEY = ACLConstants.ACCESS_LIST
     ITEM_KEY = ACLConstants.EXTENDED
 
+    KNOWN_PREFIXES = [
+        'NAT-', 'PBR-',
+        'ACL-NO-SPOOF-V4-',
+    ]
+
     @classmethod
     def __parameters__(cls):
         return [
@@ -115,8 +120,16 @@ class AccessList(NyBase):
 
     @property
     def neutron_router_id(self):
-        if self.name is not None and (self.name.startswith('NAT-') or self.name.startswith('PBR-')):
-            return utils.vrf_id_to_uuid(self.name[4:])
+        if not self.name:
+            return None
+
+        for prefix in self.KNOWN_PREFIXES:
+            if self.name.startswith(prefix):
+                break
+        else:
+            return None
+
+        return utils.vrf_id_to_uuid(self.name[len(prefix):])
 
     @property
     def policy_id(self):
@@ -158,13 +171,12 @@ class AccessList(NyBase):
             return self.policy_id not in all_fwaas_policies
         return False
 
-    def is_orphan(self, context, *args, **kwargs):
+    def is_orphan(self, *args, **kwargs):
         # Back out if we were called from the router cleanup loop and we are a FWAAS-ACL
         if self.policy_id:
             return False
 
-        return (self.name.startswith("PBR-") and self.neutron_router_id is not None) or \
-            super(AccessList, self).is_orphan(*args, context=context, **kwargs)
+        return super(AccessList, self).is_orphan(*args, **kwargs)
 
 
 class ACLRule(NyBase):

--- a/asr1k_neutron_l3/models/neutron/l3/interface.py
+++ b/asr1k_neutron_l3/models/neutron/l3/interface.py
@@ -185,8 +185,10 @@ class Interface(base.Base):
 
 class GatewayInterface(Interface):
 
-    def __init__(self, router_id, router_port, extra_atts, dynamic_nat_pool, nat_outside=True):
+    def __init__(self, router_id, router_port, extra_atts, dynamic_nat_pool, nat_outside=True,
+                 drop_int_traffic=False):
         self.dynamic_nat_pool = dynamic_nat_pool
+        self.drop_int_traffic = drop_int_traffic
         self.nat_outside = nat_outside
         super().__init__(router_id, router_port, extra_atts)
 
@@ -197,11 +199,12 @@ class GatewayInterface(Interface):
         description = (f'type:gw;router:{self.router_id};network:{self.router_port["network_id"]};'
                        f'subnet:{self._primary_v4_subnet_id or self._primary_v6_subnet_id}')
 
+        acl_out_v4 = 'EXT-TOS' if not self.drop_int_traffic else f'ACL-NO-SPOOF-V4-{self.vrf}'
         interface_args = dict(name=self.bridge_domain, description=description,
                               mac_address=self.mac_address, mtu=self.mtu, vrf=self.vrf,
                               ip_address=self.ipv4_address, ipv6_addresses=self.ipv6_addresses,
                               secondary_ip_addresses=self.secondary_ip_addresses, nat_outside=self.nat_outside,
-                              redundancy_group=None, route_map='EXT-TOS', access_group_out='EXT-TOS',
+                              redundancy_group=None, route_map='EXT-TOS', access_group_out=acl_out_v4,
                               ntp_disable=True, arp_timeout=cfg.CONF.asr1k_l3.external_iface_arp_timeout)
 
         if self.ipv6_addresses:

--- a/asr1k_neutron_l3/models/neutron/l3/router.py
+++ b/asr1k_neutron_l3/models/neutron/l3/router.py
@@ -97,6 +97,7 @@ class Router(Base):
 
         self.route_maps = self._build_route_maps()
         self.nat_acl = self._build_nat_acl()
+        self.vpnaas_antispoof_acl_v4 = self._build_vpnaas_antispoof_acl()
 
         self.bgp_address_family = self._build_bgp_address_family()
 
@@ -173,7 +174,8 @@ class Router(Base):
             self.gateway_interface = l3_interface.GatewayInterface(self.router_id, gw_port,
                                                                    self._port_extra_atts(gw_port),
                                                                    self.router_atts.get('dynamic_nat_pool'),
-                                                                   nat_outside=not self.is_vpnaas_only)
+                                                                   nat_outside=not self.is_vpnaas_only,
+                                                                   drop_int_traffic=self.is_vpnaas_only)
             interfaces.append(self.gateway_interface)
 
         inf_ports = self.router_info.get('_interfaces', [])
@@ -257,6 +259,17 @@ class Router(Base):
         else:
             acl.append_rule(access_list.Rule())
         return acl
+
+    def _build_vpnaas_antispoof_acl(self):
+        vrf_id = utils.uuid_to_vrf_id(self.router_id)
+
+        acl_v4 = access_list.AccessList(f"ACL-NO-SPOOF-V4-{vrf_id}", )
+        if self.gateway_interface and self.gateway_interface.ipv4_address:
+            rule = access_list.Rule(action='permit', source=self.gateway_interface.ipv4_address.address)
+            acl_v4.append_rule(rule)
+        acl_v4.append_rule(access_list.Rule(action='deny'))
+
+        return acl_v4
 
     def _route_has_connected_interface(self, l3_route):
         all_networks = (
@@ -557,6 +570,11 @@ class Router(Base):
         if self.nat_acl:
             results.append(self.nat_acl.update())
 
+        if self.is_vpnaas_only:
+            self.vpnaas_antispoof_acl_v4.update()
+        else:
+            self.vpnaas_antispoof_acl_v4.delete()
+
         # a router object will take care of creation of firewall acls and related objects,
         # it will also update firewall acls
         for obj in self.fwaas_conf:
@@ -634,6 +652,7 @@ class Router(Base):
         results.append(self.nat_pool.delete())
 
         results.append(self.nat_acl.delete())
+        results.append(self.vpnaas_antispoof_acl_v4.delete())
         results.append(self.bgp_address_family[4].delete())
         results.append(self.bgp_address_family[6].delete())
 
@@ -720,6 +739,10 @@ class Router(Base):
         nat_acl_diff = self.nat_acl.diff()
         if not nat_acl_diff.valid:
             diff_results['nat_acl'] = nat_acl_diff.to_dict()
+
+        spoof_acl_diff = self.vpnaas_antispoof_acl_v4.diff(should_be_none=not self.is_vpnaas_only)
+        if not spoof_acl_diff.valid:
+            diff_results['anti_spoof_acl_v4'] = spoof_acl_diff.to_dict()
 
         for obj in self.fwaas_conf:
             d = obj.diff()

--- a/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_router.py
+++ b/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_router.py
@@ -42,6 +42,8 @@ class TestRouterClass(RouterWithSyncDataTestCase):
         self.assertIsNotNone(dev_router.vrf._rest_definition.address_family_ipv4)
         self.assertIsNone(dev_router.vrf._rest_definition.address_family_ipv6)
         self.assertTrue(dev_router.gateway_interface._rest_definition.nat_outside)
+        self.assertIsNone(dev_router.gateway_interface._rest_definition.access_group_in)
+        self.assertEqual("EXT-TOS", dev_router.gateway_interface._rest_definition.access_group_out)
 
     def test_router_with_dapnet_v4(self):
         with self.address_scope(name="the-open-sea") as addr_scope, \
@@ -154,6 +156,9 @@ class TestRouterClassWithVPN(RouterWithSyncDataTestCase):
         ike_keyring = self._find_entry("IKEv2Keyring", dev_router.vpnaas_conf)._rest_definition
         self.assertEqual("supercilium", ike_keyring.peers[0].psk)
         self.assertFalse(dev_router.gateway_interface._rest_definition.nat_outside)
+        self.assertIsNone(dev_router.gateway_interface._rest_definition.access_group_in)
+        self.assertEqual(f"ACL-NO-SPOOF-V4-{dev_router.router_id.replace('-', '')}",
+                         dev_router.gateway_interface._rest_definition.access_group_out)
 
     def test_router_with_vpn_transport_conf(self):
         router = self._make_vpn_ready_router()


### PR DESCRIPTION
If we are in VPNaaS mode (VPNs present + no internal subnets) we disable NAT on the gateway interface (no ip nat outside). This could potentially lead to spoofing: If a user sends packets through the tunnel, which then are not routed to the BGPVPN this traffic might get routed via default route to the external network of the gateway, thus resulting in the fabric (in our case mostly ACI) learning the source ip of the packet controlled by the user as an endpoint on this router. To prevent this we want to only allow traffic to egress the router that originates from the router itself. This is achieved by adding an ACL to the router that contains only the router's own IPs.

---

Still missing:
 * [x] think about orphan cleaner
 * [ ] naming check
 * [x] discuss if we want to set `ip policy route-map EXT-TOS` on the interface instead (let's go with the ACL for now)