### PR TITLE
Don't return incomplete routers in get_sync_data()

### DIFF
--- a/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
@@ -275,7 +275,7 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
             host_router_ids = self.db.get_all_router_ids(context, host)
             router_ids = [r for r in router_ids if r in host_router_ids]
 
-        if not bool(router_ids):
+        if not router_ids:
             return []
 
         extra_atts = self._get_extra_atts(context, router_ids, host)
@@ -288,19 +288,16 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
             time.sleep(.25)
             routers = super(ASR1KPluginBase, self).get_sync_data(context, router_ids=router_ids, active=active)
 
-        if not bool(routers):
-            routers = []
-            for router_id in router_ids:
-                routers.append({'id': router_id, constants.ASR1K_ROUTER_ATTS_KEY: router_atts.get(router_id, {})})
+        if not routers:
+            # neutron doesn't seem to know about the routers anymore
+            return []
 
+        sync_routers = []
         for router in routers:
             extra_att = extra_atts.get(router['id'])
-            if extra_atts is None:
-                if host is None:
-                    LOG.debug("Not including router {} in sync its extra atts are missing.".format(router['id']))
-                else:
-                    LOG.debug("Not including router {} in sync its extra atts are missing for host {}."
-                              "".format(router['id'], host))
+            if extra_att is None:
+                LOG.warning("Not including router %s in sync, it's extra atts are missing (probably got deleted) - "
+                            "filter host was %s", router['id'], host)
                 continue
 
             router[constants.ASR1K_EXTRA_ATTS_KEY] = extra_att
@@ -373,7 +370,9 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
                 # only routers with an attached flavor can have VPNs
                 router["vpn"] = self.get_vpnaas_objects(context, router["id"], host)
 
-        return routers
+            sync_routers.append(router)
+
+        return sync_routers
 
     def get_vpnaas_objects(self, context, router_id, host):
         vpns = self.vpn_plugin.get_vpnservices(context, filters={'router_id': [router_id]})


### PR DESCRIPTION
The get_sync_data() method had a lot of weird logic in it, which in some cases never got triggered due to bugs. We are now trying to clean this logic up. The original problem that now let us to clean this up was a "KeyError 'flavor_id'" when vpnaas is enabled, but the router we're trying to get sync_data for is no longer in Neutron.

First thing is the creation of incomplete router dicts - I don't know why exactly this was done in 2018, but my guess is this was done to somehow support router deletion. This router deletion never worked properly and was later replaced with a "deleted router cache". The only case when this - to my knowledge - is triggered is when we have a race condition of a router getting updated and immediately after deleted. Then, the agent could ask for a non-existent router id. As the result would be an incomplete router, we're now no longer doing that. This also ever only worked for a single router id. If the agent gets an empty response from this method it will try to delete the router. This makes sense, as Neutron no longer knows about the router. If we have it in our deleted routers cache we should be fine here. If we don't have it, nothing will be done, which is fine as well.

There was also defunct protection against missing extra atts in here. The code checked if extra atts exist, but due to a typo it checked extra_atts for None instead of checking extra_att (the s at the end here being the difference). With this the code never triggered. As we only want (and can) sync routers with extra atts, we now employ that code and actually skip them.

From looking at the code this change should not cause any side effects, but as the driver is a bit complex and twisted it's hard to say for sure. The original get_sync_data() method behaves this way, though, so that's already a good indicator for it. It's at least a step in the right direction of cleaning up some old stuff.