### PR TITLE
Return routers w/o extra atts in get_sync_data()

### DIFF
--- a/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
@@ -294,13 +294,8 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
 
         sync_routers = []
         for router in routers:
-            extra_att = extra_atts.get(router['id'])
-            if extra_att is None:
-                LOG.warning("Not including router %s in sync, it's extra atts are missing (probably got deleted) - "
-                            "filter host was %s", router['id'], host)
-                continue
-
-            router[constants.ASR1K_EXTRA_ATTS_KEY] = extra_att
+            # on create the extra atts might be None, in this case they'll be creates elsewhere
+            router[constants.ASR1K_EXTRA_ATTS_KEY] = extra_atts.get(router['id'])
 
             router_att = router_atts.get(router['id'], {})
             router[constants.ASR1K_ROUTER_ATTS_KEY] = router_att


### PR DESCRIPTION
In an attempt to clean up get_sync_data() we activated a piece of code written at the creation of this driver that ignores routers without extra atts in get_sync_data(). Our assumption was wrong. The result is that router ports don't get extra atts and also somehow can not be bound due to them not having a binding host. Tracing this through the driver I am not fully sure why this is the case, but I can tell that we check for the extra atts in a couple of places, meaning the driver can perfectly handle this situation.

Therefore, to restore router creation, we're again returning these routers from get_sync_data(). This still omits routers that are no longer in the Neutron db (which was part of the last get_sync_data() code cleanup).