### PR TITLE
Don't use deprecated yang on 17.15

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/access_list.py
+++ b/asr1k_neutron_l3/models/netconf_yang/access_list.py
@@ -37,12 +37,14 @@ class ACLConstants(object):
     ANY = 'any'
     DST_ANY = 'dst-any'
     SOURCE_HOST = 'host'
+    SOURCE_HOST_ADDR = 'host-address'
     SOURCE_IP = 'ipv4-address'
     SOURCE_MASK = 'mask'
     SOURCE_EQ = 'src-eq'
     SOURCE_RANGE_START = 'src-range1'
     SOURCE_RANGE_END = 'src-range2'
     DEST_HOST = 'dst-host'
+    DEST_HOST_ADDR = 'dst-host-address'
     DEST_IP = 'dest-ipv4-address'
     DEST_MASK = 'dest-mask'
     DEST_EQ = 'dst-eq'
@@ -212,14 +214,14 @@ class ACERule(NyBase):
             {'key': 'action', 'id': True},
             {'key': 'protocol'},
             {'key': 'any', 'default': False, 'yang-type': YANG_TYPE.EMPTY},
-            {'key': 'host'},
+            {'key': 'host', 'yang-key': ACLConstants.SOURCE_HOST_ADDR},
             {'key': 'ipv4_address'},
             {'key': 'mask'},
             {'key': 'src_eq'},
             {'key': 'src_range1'},
             {'key': 'src_range2'},
             {'key': 'dst_any', 'default': False, 'yang-type': YANG_TYPE.EMPTY},
-            {'key': 'dst_host'},
+            {'key': 'dst_host', 'yang-key': ACLConstants.DEST_HOST_ADDR},
             {'key': 'dest_ipv4_address'},
             {'key': 'dest_mask'},
             {'key': 'dst_eq'},
@@ -240,7 +242,7 @@ class ACERule(NyBase):
         if self.ipv4_address is None and self.host is None:
             ace_rule[ACLConstants.ANY] = ""
         elif self.host:
-            ace_rule[ACLConstants.SOURCE_HOST] = self.host
+            ace_rule[ACLConstants.SOURCE_HOST_ADDR] = self.host
         else:
             ace_rule[ACLConstants.SOURCE_IP] = self.ipv4_address
             ace_rule[ACLConstants.SOURCE_MASK] = self.mask
@@ -255,7 +257,7 @@ class ACERule(NyBase):
         if self.dest_ipv4_address is None and self.dst_host is None:
             ace_rule[ACLConstants.DST_ANY] = ""
         elif self.dst_host:
-            ace_rule[ACLConstants.DEST_HOST] = self.dst_host
+            ace_rule[ACLConstants.DEST_HOST_ADDR] = self.dst_host
         else:
             ace_rule[ACLConstants.DEST_IP] = self.dest_ipv4_address
             ace_rule[ACLConstants.DEST_MASK] = self.dest_mask

--- a/asr1k_neutron_l3/models/netconf_yang/l2_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l2_interface.py
@@ -48,7 +48,9 @@ class L2Constants(object):
     SECOND_DOT1Q = "second-dot1q"
     INGRESS = "ingress"
     TAG = "tag"
+    TAG_CONFIG = "tag-config"
     POP = "pop"
+    POP_OP = "pop-op"
     REWRITE = "rewrite"
     REWRITE_WAY = "way"
     REWRITE_MODE = "mode"
@@ -297,8 +299,8 @@ class ServiceInstance(NyBase):
             {"key": "bridge_domain", 'yang-path': 'bridge-domain', 'yang-key': 'bridge-id'},
             {"key": "dot1q", 'yang-path': 'encapsulation/dot1q', 'yang-key': 'id'},
             {"key": "second_dot1q", 'yang-path': 'encapsulation/dot1q', 'yang-key': 'second-dot1q'},
-            {"key": "way", 'yang-path': 'rewrite/ingress/tag/pop'},
-            {"key": "mode", 'yang-path': 'rewrite/ingress/tag/pop'}
+            {"key": "way", 'yang-path': 'rewrite/ingress/tag-config/pop-op'},
+            {"key": "mode", 'yang-path': 'rewrite/ingress/tag-config/pop-op'}
         ]
 
     @classmethod
@@ -375,12 +377,12 @@ class ServiceInstance(NyBase):
         rewrite = OrderedDict()
         rewrite[L2Constants.INGRESS] = OrderedDict()
 
-        rewrite[L2Constants.INGRESS][L2Constants.TAG] = OrderedDict()
+        rewrite[L2Constants.INGRESS][L2Constants.TAG_CONFIG] = tag_config = {}
         if self.way is not None and self.mode is not None:
-            rewrite[L2Constants.INGRESS][L2Constants.TAG][L2Constants.POP] = OrderedDict()
-            rewrite[L2Constants.INGRESS][L2Constants.TAG][L2Constants.POP][
-                L2Constants.REWRITE_WAY] = self.way
-            rewrite[L2Constants.INGRESS][L2Constants.TAG][L2Constants.POP][L2Constants.REWRITE_MODE] = self.mode
+            tag_config[L2Constants.POP_OP] = {
+                L2Constants.REWRITE_WAY: self.way,
+                L2Constants.REWRITE_MODE: self.mode
+            }
 
         instance = OrderedDict()
         instance[L2Constants.ID] = "{}".format(str(self.id))

--- a/asr1k_neutron_l3/models/netconf_yang/route_map.py
+++ b/asr1k_neutron_l3/models/netconf_yang/route_map.py
@@ -42,6 +42,7 @@ class RouteMapConstants(object):
     ADDRESS = "address"
     ASN = "asn-nn"
     PREFIX_LIST = "prefix-list"
+    PREFIX_LIST_ORDERED = "prefix-list-ordered"
     ACCESS_LIST = "access-list"
     PRECEDENCE = "precedence"
     PRECEDENCE_FIELDS = "precedence-fields"
@@ -141,7 +142,7 @@ class MapSequence(NyBase):
             {'key': 'next_hop', 'yang-key': 'address', 'yang-path': 'set/ip/next-hop/next-hop-addr'},
             {'key': 'force', 'yang-path': 'set/ip/next-hop/next-hop-addr', 'default': False,
              'yang-type': YANG_TYPE.EMPTY},
-            {'key': 'prefix_list', 'yang-key': 'prefix-list', 'yang-path': 'match/ip/address'},
+            {'key': 'prefix_list', 'yang-key': 'prefix-list-ordered', 'yang-path': 'match/ip/address'},
             {'key': 'prefix_list_v6', 'yang-key': 'prefix-list', 'yang-path': 'match/ipv6/address'},
             {'key': 'access_list', 'yang-key': 'access-list', 'yang-path': 'match/ip/address'},
             {'key': 'ip_precedence', 'yang-path': 'set/ip/precedence', 'yang-key': 'precedence-fields'},
@@ -201,7 +202,7 @@ class MapSequence(NyBase):
             entry = seq.setdefault(RouteMapConstants.MATCH, {})
             if self.prefix_list:
                 entry[RouteMapConstants.IP] = {
-                    RouteMapConstants.ADDRESS: {RouteMapConstants.PREFIX_LIST: self.prefix_list}}
+                    RouteMapConstants.ADDRESS: {RouteMapConstants.PREFIX_LIST_ORDERED: self.prefix_list}}
             if self.prefix_list_v6:
                 entry[RouteMapConstants.IPV6] = {
                     RouteMapConstants.ADDRESS: {RouteMapConstants.PREFIX_LIST: self.prefix_list_v6}}


### PR DESCRIPTION
With fw 17.15.2a some queries are way slower than they have been on 17.6 - especially fetching "nat-static-transport-list-with-vrf". After a few month of investigation our vendor told us that we can improve YANG speed by disabling deprecated models with the following command:

conf t
yang-interfaces feature deprecated disable

This seems to improve query time. In a test with 195 fips it goes down from ~5s - 5.3s to ~1.7s -1.9s.

To actually use this flag we need to remove all deprecated uses we can find:

route-map: for IPv4 we now need to reference prefix lists with prefix-list-ordered, as this container has a "user-ordered" or something like that. IPv6 remains unchanged and still uses prefix-list.

port-channel: for service-instance, some config moved in tag-config/pop-op.

access-list: host / dst-host are now named host-address / dst-host-address.

With this commit we drop compatibility with fw 17.6.