### PR TITLE
No deprecated yang on 17.15 for crypto / Tunnel

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/crypto.py
+++ b/asr1k_neutron_l3/models/netconf_yang/crypto.py
@@ -116,7 +116,6 @@ class IPSecProfile(NyBase):
             {'key': 'transform_set', 'yang-path': 'set'},
             {'key': 'pfs', 'yang-key': 'group', 'yang-path': 'set/pfs'},
 
-            {'key': 'sa_lifetime_sec', 'yang-key': 'seconds', 'yang-path': 'set/security-association/lifetime'},
             {'key': 'sa_lifetime_sec_case', 'yang-key': 'seconds-case',
              'yang-path': 'set/security-association/lifetime'},
             {'key': 'sa_lifetime_kb', 'yang-key': 'kilobytes', 'yang-path': 'set/security-association/lifetime'},
@@ -138,12 +137,11 @@ class IPSecProfile(NyBase):
         if self.pfs:
             p_set[CryptoConstants.PFS] = {CryptoConstants.GROUP: self.pfs}
 
-        if self.sa_lifetime_sec or self.sa_lifetime_sec_case or self.sa_lifetime_kb:
+        if self.sa_lifetime_sec_case or self.sa_lifetime_kb:
             p_set[CryptoConstants.SECURITY_ASSOCIATION] = {
                 CryptoConstants.LIFETIME: {
                     CryptoConstants.SECONDS_CASE: self.sa_lifetime_sec_case,
                     CryptoConstants.KILOBYTES: self.sa_lifetime_kb,
-                    CryptoConstants.SECONDS: self.sa_lifetime_sec,
                 }
             }
 

--- a/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
+++ b/asr1k_neutron_l3/models/netconf_yang/l3_interface.py
@@ -88,7 +88,10 @@ class L3Constants(object):
     TCP = "tcp"
     SOURCE = "source"
     IPV4 = "ipv4"
+    IPV4_MODE = "ipv4-mode"
+    IPV6_MODE = "ipv6-mode"
     DUAL_OVERLAY = "dual-overlay"
+    DUAL_OVERLAY_MODE = "dual-overlay-mode"
     DESTINATION_CONFIG = "destination-config"
     IPSEC = "ipsec"
     MODE = "mode"
@@ -579,11 +582,11 @@ class TunnelInterface(NyBase):
             {'key': 'tunnel_dest_ipv4', 'yang-key': 'ipv4', 'yang-path': 'tunnel/destination-config'},
             {'key': 'tunnel_dest_ipv6', 'yang-key': 'ipv6', 'yang-path': 'tunnel/destination-config'},
 
-            {'key': 'tunnel_mode_ipsec_ipv4', 'yang-key': 'ipv4', 'yang-path': 'tunnel/mode/ipsec',
+            {'key': 'tunnel_mode_ipsec_ipv4', 'yang-key': 'ipv4-mode', 'yang-path': 'tunnel/mode/ipsec',
              'yang-type': YANG_TYPE.EMPTY},
-            {'key': 'tunnel_mode_ipsec_ipv6', 'yang-key': 'ipv6', 'yang-path': 'tunnel/mode/ipsec',
+            {'key': 'tunnel_mode_ipsec_ipv6', 'yang-key': 'ipv6-mode', 'yang-path': 'tunnel/mode/ipsec',
              'yang-type': YANG_TYPE.EMPTY},
-            {'key': 'tunnel_mode_ipsec_dual_overlay', 'yang-key': 'dual-overlay', 'yang-path': 'tunnel/mode/ipsec',
+            {'key': 'tunnel_mode_ipsec_dual_overlay', 'yang-key': 'dual-overlay-mode', 'yang-path': 'tunnel/mode/ipsec',
              'yang-type': YANG_TYPE.EMPTY},
             {'key': 'path_mtu_discovery', 'yang-path': 'tunnel', 'yang-type': YANG_TYPE.EMPTY},
 
@@ -663,11 +666,11 @@ class TunnelInterface(NyBase):
                 dest_config[L3Constants.IPV6] = self.tunnel_dest_ipv6
             tun[L3Constants.DESTINATION_CONFIG] = dest_config
         if self.tunnel_mode_ipsec_ipv4:
-            tun[L3Constants.MODE] = {L3Constants.IPSEC: {L3Constants.IPV4: ""}}
+            tun[L3Constants.MODE] = {L3Constants.IPSEC: {L3Constants.IPV4_MODE: ""}}
         if self.tunnel_mode_ipsec_ipv6:
-            tun[L3Constants.MODE] = {L3Constants.IPSEC: {L3Constants.IPV6: ""}}
+            tun[L3Constants.MODE] = {L3Constants.IPSEC: {L3Constants.IPV6_MODE: ""}}
         if self.tunnel_mode_ipsec_dual_overlay:
-            tun[L3Constants.MODE] = {L3Constants.IPSEC: {L3Constants.DUAL_OVERLAY: ""}}
+            tun[L3Constants.MODE] = {L3Constants.IPSEC: {L3Constants.DUAL_OVERLAY_MODE: ""}}
         if self.path_mtu_discovery:
             tun[L3Constants.PATH_MTU_DISCOVERY] = ""
 

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_crypto.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_crypto.py
@@ -39,7 +39,6 @@ class CryptoSerialization(base.BaseTestCase):
                 <lifetime>
                   <seconds-case>1338</seconds-case>
                   <kilobytes>disable</kilobytes>
-                  <seconds>1337</seconds>
                 </lifetime>
               </security-association>
             </set>
@@ -58,7 +57,6 @@ class CryptoSerialization(base.BaseTestCase):
         self.assertEqual("AES256_SHA512_Tunnel", prof.transform_set)
         self.assertEqual("my-very-first-profile", prof.ikev2_profile)
         self.assertEqual("group21", prof.pfs)
-        self.assertEqual("1337", prof.sa_lifetime_sec)
         self.assertEqual("1338", prof.sa_lifetime_sec_case)
         self.assertEqual("disable", prof.sa_lifetime_kb)
         self.assertEqual("group21", prof.pfs)
@@ -69,7 +67,7 @@ class CryptoSerialization(base.BaseTestCase):
         context = FakeASR1KContext()
         prof = crypto.IPSecProfile(name="no-crypto-just-meowmeow", reverse_route=True,
                                    transform_set="from-here-to-there", ikev2_profile="itsa-meeee",
-                                   pfs="group9999", sa_lifetime_sec=1337,
+                                   pfs="group9999",
                                    sa_lifetime_sec_case=1338,
                                    sa_lifetime_kb="disable",)
         self.assertEqual({
@@ -81,7 +79,6 @@ class CryptoSerialization(base.BaseTestCase):
                     'security-association': {
                         'lifetime': {
                             'kilobytes': 'disable',
-                            'seconds': '1337',
                             'seconds-case': '1338'}
                     },
                     'transform-set': 'from-here-to-there'

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_l3_interface.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_l3_interface.py
@@ -63,7 +63,6 @@ class TestL3Interface(base.BaseTestCase):
             <mode>
               <ipsec>
                 <ipv4-mode/>
-                <ipv4/>
               </ipsec>
             </mode>
             <path-mtu-discovery/>
@@ -143,7 +142,7 @@ class TestL3Interface(base.BaseTestCase):
                 '@xmlns': 'http://cisco.com/ns/yang/Cisco-IOS-XE-tunnel',
                 'source': '1.1.1.1',
                 'destination-config': {'ipv4': '1.1.1.2'},
-                'mode': {'ipsec': {'ipv4': ''}},
+                'mode': {'ipsec': {'ipv4-mode': ''}},
                 'path-mtu-discovery': '',
                 'protection': {'ipsec': {
                     '@xmlns': 'http://cisco.com/ns/yang/Cisco-IOS-XE-crypto',


### PR DESCRIPTION
For VPNaaS routers we need to do some extra updates to not use any deprecated yang on 17.15.2a:

Tunnel interface: tunnel mode tags now have an extra -mode in their name, so for example for dual-overlay the path is now tunnel/mode/ipsec/dual-overlay-mode. Same thing for ipv4/ipv6 mode.

crypto ipsec profile: the "seconds" case is no longer available and is now called "seconds-case". We used to support both, but we only need the second case seconds-case.