### PR TITLE
Add scope config to ext sync data API

### DIFF
--- a/asr1k_neutron_l3/extensions/asr1koperations.py
+++ b/asr1k_neutron_l3/extensions/asr1koperations.py
@@ -215,6 +215,7 @@ class ConfigController(wsgi.Controller):
             if not data:
                 raise exceptions.HTTPNotFound(detail=f'No router found for uuid "{id}"')
             data = jsonutils.to_primitive(data[0], convert_instances=True)
+            data[const.ADDRESS_SCOPE_CONFIG] = self.plugin.get_address_scope_config(request.context)
             return {"config": data}
         except BaseException as e:
             raise exceptions.HTTPInternalServerError(detail=str(e))

--- a/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
+++ b/asr1k_neutron_l3/plugins/l3/service_plugins/l3_extension_adapter.py
@@ -432,6 +432,11 @@ class ASR1KPluginBase(l3_db.L3_NAT_db_mixin,
     def get_deleted_router_atts(self, context):
         return self.db.get_deleted_router_atts(context)
 
+    def get_address_scope_config(self, context):
+        scopes_cfg = asr1k_config.create_address_scope_dict()
+        scopes_db = self.db.get_address_scopes(context, filters={"name": list(scopes_cfg.keys())})
+        return {scope['id']: scopes_cfg[scope['name']] for scope in scopes_db}
+
     def get_flavor_metainfo_entries(self, context, flavor_id):
         """Fetch the metainfo of all service profiles referenced by a flavor"""
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,10 @@ envlist = py310
 minversion = 3.18.0
 skipsdist = True
 
+# specify virtualenv here to keep local runs consistent with the
+# gate (it sets the versions of pip, setuptools, and wheel)
+requires = virtualenv<20.38
+
 [testenv]
 install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}


### PR DESCRIPTION
We have an API for admins/devs to fetch the sync data of a router that can be used to debug internal router state. The agent itself adds an address scope config (e.g. to configure DAPNets). To make the sync data structure provided by the API similar to what the agent sees (and allow devs to actually instantiate routers in a similar way as the agent does) we need to add this config.

Long term we could also reconsider this and let sync_data() add this config to the data structure alltogether.