### PR TITLE
Add description to Tunnel interface

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/vpn.py
+++ b/asr1k_neutron_l3/models/neutron/l3/vpn.py
@@ -18,7 +18,7 @@ import ipaddress
 
 from oslo_log import log as logging
 
-from asr1k_neutron_l3.common.utils import uuid_to_ipsec_short_id, uuid_to_vrf_id
+from asr1k_neutron_l3.common.utils import uuid_to_ipsec_short_id, uuid_to_vrf_id, vrf_id_to_uuid
 from asr1k_neutron_l3.models.neutron.l3 import access_list, base
 from asr1k_neutron_l3.models.netconf_yang import crypto, l3_interface
 
@@ -223,6 +223,10 @@ class TunnelInterface(base.Base):
     def __init__(self, vrf, sitecon, external_v4_ip, external_v6_ip, vpn_service_up=True):
         super().__init__()
 
+        # this description has a 200 char limit in netconf-yaxng
+        self.description = (f"type:vpn;project:{sitecon['project_id']};router:{vrf_id_to_uuid(vrf)};"
+                            f"sitecon:{sitecon['id']};profile:{uuid_to_ipsec_short_id(sitecon['id'])}")
+
         self.vrf = vrf
         self.external_v4_ip = external_v4_ip
         self.external_v6_ip = external_v6_ip
@@ -253,10 +257,10 @@ class TunnelInterface(base.Base):
 
         self._rest_definition = l3_interface.TunnelInterface(
             name=self.tunnel_id,
+            description=self.description,
             shutdown=self.shutdown,
             vrf=vrf,
             tunnel_vrf=vrf,
-            description=sitecon['id'],
             mtu=sitecon['mtu'],
             # tcp mss = mtu - (20 bytes ip header + 20 bytes tcp header)
             tcp_mss=sitecon['mtu'] - 40,


### PR DESCRIPTION
The description of the interface ends up in Prometheus and can to match the interface to OpenStack objects. We include project id, router id, ipsec site connection id and the derived ipsec profile name. Including the derived name makes it later easier to consume the data, so we don't need to convert ids in Prometheus (or in other places where this is consumed). We don't include the vpn service id, as this has a 1:1 correlation to the router (and there was nobody specifically asking for it).

The description field for the Tunnel interface has a 200 character limit in netconf-yang.