### PR TITLE
Only show VPNaaS data for router in config api

### DIFF
--- a/asr1k_neutron_l3/plugins/db/asr1k_db.py
+++ b/asr1k_neutron_l3/plugins/db/asr1k_db.py
@@ -722,9 +722,9 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
     @db_api.CONTEXT_READER
     def get_vpn_internal_tunnel_ips(self, context, ipsec_sitecon_ids=None, vpnservice_id=None):
         query = context.session.query(asr1k_models.ASR1KInternalTunnelIp)
-        if ipsec_sitecon_ids:
+        if ipsec_sitecon_ids is not None:
             query = query.filter(asr1k_models.ASR1KInternalTunnelIp.ipsec_site_connection_id.in_(ipsec_sitecon_ids))
-        if vpnservice_id:
+        if vpnservice_id is not None:
             query = query.join(vpn_models.IPsecSiteConnection,
                                asr1k_models.ASR1KInternalTunnelIp.ipsec_site_connection_id ==
                                vpn_models.IPsecSiteConnection.id)
@@ -779,7 +779,7 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
     def get_vpn_tunnel_ids(self, context, ipsec_site_connection_ids=None, agent_host=None):
         query = context.session.query(asr1k_models.ASR1KTunnelId)
 
-        if ipsec_site_connection_ids:
+        if ipsec_site_connection_ids is not None:
             query = query.filter(asr1k_models.ASR1KTunnelId.ipsec_site_connection_id.in_(ipsec_site_connection_ids))
         if agent_host:
             query = query.filter(asr1k_models.ASR1KTunnelId.agent_host == agent_host)


### PR DESCRIPTION
Previously we showed non-matching internal VPNaaS ips and tunnel ids for routers that don't have a ipsec site connection (or vpn service) attached. This was due to a missing "is None" check in get_vpn_internal_tunnel_ips() or get_vpn_tunnel_ids(). When these methods get an empty list this evaluated as false, causing the functions to not apply any filtering at all. With "is not None" we now also apply the filter when an empty list is passed. Now the config API endpoint does not display any non-matching ipsec site connections for unaffiliated router anymore.