### PR TITLE
vpnaas: Fix IKEv2 proposal with aes-gcm

### DIFF
--- a/asr1k_neutron_l3/models/netconf_yang/crypto.py
+++ b/asr1k_neutron_l3/models/netconf_yang/crypto.py
@@ -522,7 +522,10 @@ class IKEv2Proposal(NyBase):
         for enc in cls.ENCRYPTION_ALGOS:
             params.append({'key': enc, 'yang-path': 'encryption', 'yang-type': YANG_TYPE.EMPTY, 'default': False})
         for hashalgo in cls.HASHES:
-            params.append({'key': hashalgo, 'yang-path': 'integrity', 'yang-type': YANG_TYPE.EMPTY, 'default': False})
+            params.append({'key': f'int_{hashalgo}', 'yang-key': hashalgo, 'yang-path': 'integrity',
+                           'yang-type': YANG_TYPE.EMPTY, 'default': False})
+            params.append({'key': f'prf_{hashalgo}', 'yang-key': hashalgo, 'yang-path': 'prf',
+                           'yang-type': YANG_TYPE.EMPTY, 'default': False})
 
         return params
 
@@ -531,12 +534,17 @@ class IKEv2Proposal(NyBase):
             CryptoConstants.NAME: self.name,
         }
 
-        for (key, values) in ((CryptoConstants.ENCRYPTION, self.ENCRYPTION_ALGOS), (CryptoConstants.GROUP, self.GROUPS),
-                              (CryptoConstants.INTEGRITY, self.HASHES)):
+        for (key, values) in ((CryptoConstants.ENCRYPTION, self.ENCRYPTION_ALGOS), (CryptoConstants.GROUP, self.GROUPS)):
             for value in values:
                 if getattr(self, value):
                     # transform to yang-key
                     value = value.replace("_", "-")
                     prop.setdefault(key, {})[value] = ""
+
+        for hashalgo in self.HASHES:
+            if getattr(self, f'int_{hashalgo}'):
+                prop.setdefault(CryptoConstants.INTEGRITY, {})[hashalgo] = ""
+            if getattr(self, f'prf_{hashalgo}'):
+                prop.setdefault(CryptoConstants.PRF, {})[hashalgo] = ""
 
         return {CryptoConstants.PROPOSAL: prop}

--- a/asr1k_neutron_l3/models/neutron/l3/vpn.py
+++ b/asr1k_neutron_l3/models/neutron/l3/vpn.py
@@ -46,12 +46,20 @@ class IKEv2Proposal(base.Base):
         if enc in ('aes-128', 'aes-256'):
             parts = enc.split("-")
             enc = f"{parts[0]}-cbc-{parts[1]}"
+        elif enc in ('aes-128-gcm-16', 'aes-256-gcm-16'):
+            parts = enc.split("-")
+            enc = f"{parts[0]}-gcm-{parts[1]}"
         enc = enc.replace("-", "_")
         extra_args[enc] = True
 
         # hash algo
         if hash_algo := ikepolicy['auth_algorithm']:
-            extra_args[hash_algo] = True
+            if '-gcm-' in ikepolicy['encryption_algorithm']:
+                # gcm uses prf instead of integrity
+                hash_key = f'prf_{hash_algo}'
+            else:
+                hash_key = f'int_{hash_algo}'
+            extra_args[hash_key] = True
 
         # dh
         if dh := ikepolicy['pfs']:

--- a/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_crypto.py
+++ b/asr1k_neutron_l3/tests/unit/models/netconf_yang/test_crypto.py
@@ -479,6 +479,9 @@ class CryptoSerialization(base.BaseTestCase):
             <integrity>
               <sha256/>
             </integrity>
+            <prf>
+              <sha512/>
+            </prf>
           </proposal>
         </ikev2>
       </crypto>
@@ -505,21 +508,37 @@ class CryptoSerialization(base.BaseTestCase):
         self.assertFalse(prop.aes_gcm_128)
         self.assertFalse(prop.aes_gcm_256)
 
-        self.assertTrue(prop.sha256)
-        self.assertFalse(prop.sha384)
-        self.assertFalse(prop.sha512)
+        self.assertTrue(prop.int_sha256)
+        self.assertFalse(prop.int_sha384)
+        self.assertFalse(prop.int_sha512)
+
+        self.assertFalse(prop.prf_sha256)
+        self.assertFalse(prop.prf_sha384)
+        self.assertTrue(prop.prf_sha512)
+
+        self.assertEqual({"name": "eurasian-starling",
+                          "encryption": {"aes-cbc-256": ""},
+                          "group": {"nineteen": "", "twenty-one": ""},
+                          "integrity": {"sha256": ""},
+                          "prf": {"sha512": ""}},
+                         prop.to_dict(context)["proposal"])
+
+    def test_ikev2_proposal_serialization(self):
+        context = FakeASR1KContext()
+        prop = crypto.IKEv2Proposal(name="eurasian-starling", nineteen=True, twenty_one=True,
+                                    aes_cbc_256=True, int_sha256=True)
         self.assertEqual({"name": "eurasian-starling",
                           "encryption": {"aes-cbc-256": ""},
                           "group": {"nineteen": "", "twenty-one": ""},
                           "integrity": {"sha256": ""}},
                          prop.to_dict(context)["proposal"])
 
-    def test_ikev2_proposal_serialization(self):
+    def test_ikev2_proposal_serialization_prf(self):
         context = FakeASR1KContext()
         prop = crypto.IKEv2Proposal(name="eurasian-starling", nineteen=True, twenty_one=True,
-                                    aes_cbc_256=True, sha256=True)
+                                    aes_gcm_256=True, prf_sha256=True)
         self.assertEqual({"name": "eurasian-starling",
-                          "encryption": {"aes-cbc-256": ""},
+                          "encryption": {"aes-gcm-256": ""},
                           "group": {"nineteen": "", "twenty-one": ""},
-                          "integrity": {"sha256": ""}},
+                          "prf": {"sha256": ""}},
                          prop.to_dict(context)["proposal"])

--- a/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_router.py
+++ b/asr1k_neutron_l3/tests/unit/models/neutron/l3/test_router.py
@@ -239,3 +239,27 @@ class TestRouterClassWithVPN(RouterWithSyncDataTestCase):
         dev_router = self._get_ny_router(router['router']['id'])
         iface = self._find_entry("TunnelInterface", dev_router.vpnaas_conf)._rest_definition
         self.assertTrue(iface.shutdown)
+
+    def test_router_with_aes_gcm(self):
+        router = self._make_vpn_ready_router()
+        vpn = self._create_vpnservice("json", "vpn1", True, router['router']['id'], None, as_admin=True)
+        self._create_ipsec_site_connection("json",
+            vpnservice_id=vpn["vpnservice"]["id"],
+            **self._make_sitecon_related_objs(peer_eps=["193.175.214.0/24"],
+                                              ike_args={"encryption_algorithm": "aes-256-gcm-16",
+                                                        "auth_algorithm": "sha512"},
+                                              ipsec_args={"encryption_algorithm": "aes-256-gcm-16",
+                                                          "auth_algorithm": "sha512"})
+        )
+        dev_router = self._get_ny_router(router['router']['id'])
+
+        # make sure prf_$hash is set, but $hash is not
+        ike_prop = self._find_entry("IKEv2Proposal", dev_router.vpnaas_conf)._rest_definition
+        self.assertTrue(ike_prop.aes_gcm_256)
+        self.assertTrue(ike_prop.prf_sha512)
+        self.assertFalse(ike_prop.int_sha512)
+        self.assertTrue(ike_prop.fifteen)
+        self.assertIn('sha512', ike_prop.to_dict(context)['proposal']['prf'])
+
+        ipsec_ts = self._find_entry("IPSecTransformSet", dev_router.vpnaas_conf)._rest_definition
+        self.assertIsNone(ipsec_ts.esp_hmac)


### PR DESCRIPTION
A crypto ikev2 proposal with aes-gcm-based encryption requires us to NOT set integrity, but to instead set prf on the proposal. This patch fixes that by adding the necessary fields to the yang model and to also properly set the required values in the neutron model.

While we need to set the right integrity/prf field, we also need to actually set the right encryption field. Due to some naming issues, before this patch we set aes_256_gcm_16. What we actually want to set is aes-gcm-$bits, so we now properly translate the encryption algorithm to this value.