### PR TITLE
Disable FWaaS drop logging

### DIFF
--- a/asr1k_neutron_l3/models/neutron/l3/firewall.py
+++ b/asr1k_neutron_l3/models/neutron/l3/firewall.py
@@ -120,7 +120,7 @@ class ServicePolicy(FirewallPolicyMixin, base.Base):
         classes = [
             ncServicePolicyClass(id=ClassMap.get_id_by_policy_id(self.policy_id),
                                  type='inspect', policy_action='inspect'),
-            ncServicePolicyClass(id='class-default', policy_action='drop', log=True)
+            ncServicePolicyClass(id='class-default', policy_action='drop', log=False)
         ]
         return ncServicePolicy(id=self.id, type='inspect', classes=classes)
 


### PR DESCRIPTION
We don't want to swamp our device logs with logging dropped packets, therefore we're disabling this.